### PR TITLE
Add requirement comments

### DIFF
--- a/src/openvic-dataloader/v2script/Parser.cpp
+++ b/src/openvic-dataloader/v2script/Parser.cpp
@@ -160,6 +160,12 @@ constexpr Parser& Parser::load_from_file(const detail::Has_c_str auto& path) {
 	return load_from_file(path.c_str());
 }
 
+/* REQUIREMENTS:
+ * DAT-23
+ * DAT-26
+ * DAT-28
+ * DAT-29
+ */
 bool Parser::simple_parse() {
 	if (!_buffer_handler->is_valid()) {
 		return false;


### PR DESCRIPTION
Moved compound value expression to ValueExpression rule

Fulfills:
DAT-23, DAT-26, DAT-28, DAT-29,
DAT-626, DAT-627, DAT-628, DAT-630,
DAT-631, DAT-632, DAT-633, DAT-634,
DAT-635, DAT-636, DAT-638, DAT-639,
DAT-640, DAT-641, DAT-642, DAT-643