### PR TITLE
Add ParseOptions

### DIFF
--- a/src/openvic-dataloader/v2script/DecisionGrammar.hpp
+++ b/src/openvic-dataloader/v2script/DecisionGrammar.hpp
@@ -23,25 +23,25 @@ namespace ovdl::v2script::grammar {
 	// Macros
 	//////////////////
 // Produces <KW_NAME>_rule and <KW_NAME>_p
-#define OVDL_GRAMMAR_KEYWORD_DEFINE(KW_NAME)                                                    \
-	struct KW_NAME##_rule {                                                                     \
-		static constexpr auto keyword = LEXY_KEYWORD(#KW_NAME, lexy::dsl::inline_<Identifier>); \
-		static constexpr auto rule = keyword >> lexy::dsl::equal_sign;                          \
-		static constexpr auto value = lexy::noop;                                               \
-	};                                                                                          \
+#define OVDL_GRAMMAR_KEYWORD_DEFINE(KW_NAME)                                                                        \
+	struct KW_NAME##_rule {                                                                                         \
+		static constexpr auto keyword = LEXY_KEYWORD(#KW_NAME, lexy::dsl::inline_<Identifier<StringEscapeOption>>); \
+		static constexpr auto rule = keyword >> lexy::dsl::equal_sign;                                              \
+		static constexpr auto value = lexy::noop;                                                                   \
+	};                                                                                                              \
 	static constexpr auto KW_NAME##_p = lexy::dsl::p<KW_NAME##_rule>
 
 // Produces <KW_NAME>_rule and <KW_NAME>_p and <KW_NAME>_rule::flag and <KW_NAME>_rule::too_many_error
-#define OVDL_GRAMMAR_KEYWORD_FLAG_DEFINE(KW_NAME)                                               \
-	struct KW_NAME##_rule {                                                                     \
-		static constexpr auto keyword = LEXY_KEYWORD(#KW_NAME, lexy::dsl::inline_<Identifier>); \
-		static constexpr auto rule = keyword >> lexy::dsl::equal_sign;                          \
-		static constexpr auto value = lexy::noop;                                               \
-		static constexpr auto flag = lexy::dsl::context_flag<struct KW_NAME##_context>;         \
-		struct too_many_error {                                                                 \
-			static constexpr auto name = "expected left side " #KW_NAME " to be found once";    \
-		};                                                                                      \
-	};                                                                                          \
+#define OVDL_GRAMMAR_KEYWORD_FLAG_DEFINE(KW_NAME)                                                                   \
+	struct KW_NAME##_rule {                                                                                         \
+		static constexpr auto keyword = LEXY_KEYWORD(#KW_NAME, lexy::dsl::inline_<Identifier<StringEscapeOption>>); \
+		static constexpr auto rule = keyword >> lexy::dsl::equal_sign;                                              \
+		static constexpr auto value = lexy::noop;                                                                   \
+		static constexpr auto flag = lexy::dsl::context_flag<struct KW_NAME##_context>;                             \
+		struct too_many_error {                                                                                     \
+			static constexpr auto name = "expected left side " #KW_NAME " to be found once";                        \
+		};                                                                                                          \
+	};                                                                                                              \
 	static constexpr auto KW_NAME##_p = lexy::dsl::p<KW_NAME##_rule> >> (lexy::dsl::must(KW_NAME##_rule::flag.is_reset()).error<KW_NAME##_rule::too_many_error> + KW_NAME##_rule::flag.set())
 	//////////////////
 	// Macros
@@ -49,7 +49,7 @@ namespace ovdl::v2script::grammar {
 	struct DecisionStatement {
 		template<auto Production, typename AstNode>
 		struct _StringStatement {
-			static constexpr auto rule = Production >> (lexy::dsl::p<StringExpression> | lexy::dsl::p<Identifier>);
+			static constexpr auto rule = Production >> (lexy::dsl::p<StringExpression<StringEscapeOption>> | lexy::dsl::p<Identifier<StringEscapeOption>>);
 			static constexpr auto value = lexy::forward<ast::NodePtr>;
 		};
 		template<auto Production, typename AstNode>
@@ -72,14 +72,14 @@ namespace ovdl::v2script::grammar {
 			constexpr auto effect_statement = effect_p >> lexy::dsl::p<TriggerBlock>;
 			constexpr auto ai_will_do_statement = ai_will_do_p >> lexy::dsl::p<AiBehaviorBlock>;
 
-			return lexy::dsl::p<Identifier> >>
+			return lexy::dsl::p<Identifier<StringEscapeOption>> >>
 				   (create_flags + lexy::dsl::equal_sign +
 					   lexy::dsl::curly_bracketed.list(
 						   potential_statement |
 						   allow_statement |
 						   effect_statement |
 						   ai_will_do_statement |
-						   lexy::dsl::p<SimpleAssignmentStatement>));
+						   lexy::dsl::p<SimpleAssignmentStatement<StringEscapeOption>>));
 		}();
 
 		static constexpr auto value =
@@ -95,7 +95,7 @@ namespace ovdl::v2script::grammar {
 
 	struct DecisionList {
 		static constexpr auto rule =
-			LEXY_KEYWORD("political_decisions", lexy::dsl::inline_<Identifier>) >>
+			LEXY_KEYWORD("political_decisions", lexy::dsl::inline_<Identifier<StringEscapeOption>>) >>
 			(lexy::dsl::equal_sign + lexy::dsl::curly_bracketed.opt_list(lexy::dsl::p<DecisionStatement>));
 
 		static constexpr auto value =
@@ -116,7 +116,7 @@ namespace ovdl::v2script::grammar {
 		static constexpr auto rule =
 			lexy::dsl::terminator(lexy::dsl::eof).list( //
 				lexy::dsl::p<DecisionList> |			//
-				lexy::dsl::p<SimpleAssignmentStatement>);
+				lexy::dsl::p<SimpleAssignmentStatement<StringEscapeOption>>);
 
 		static constexpr auto value = lexy::as_list<std::vector<ast::NodePtr>> >> lexy::new_<ast::FileNode, ast::NodePtr>;
 	};

--- a/src/openvic-dataloader/v2script/EffectGrammar.hpp
+++ b/src/openvic-dataloader/v2script/EffectGrammar.hpp
@@ -9,7 +9,7 @@
 
 namespace ovdl::v2script::grammar {
 	struct EffectStatement {
-		static constexpr auto rule = lexy::dsl::inline_<SimpleAssignmentStatement>;
+		static constexpr auto rule = lexy::dsl::inline_<SimpleAssignmentStatement<StringEscapeOption>>;
 
 		static constexpr auto value = lexy::callback<ast::NodePtr>(
 			[](auto name, auto&& initalizer) {
@@ -18,7 +18,7 @@ namespace ovdl::v2script::grammar {
 	};
 
 	struct EffectList {
-		static constexpr auto rule = lexy::dsl::list(lexy::dsl::p<SimpleAssignmentStatement>);
+		static constexpr auto rule = lexy::dsl::list(lexy::dsl::p<SimpleAssignmentStatement<StringEscapeOption>>);
 
 		static constexpr auto value =
 			lexy::as_list<std::vector<ast::NodePtr>> >>

--- a/src/openvic-dataloader/v2script/EventGrammar.hpp
+++ b/src/openvic-dataloader/v2script/EventGrammar.hpp
@@ -21,25 +21,25 @@ namespace ovdl::v2script::grammar {
 	// Macros
 	//////////////////
 // Produces <KW_NAME>_rule and <KW_NAME>_p
-#define OVDL_GRAMMAR_KEYWORD_DEFINE(KW_NAME)                                                    \
-	struct KW_NAME##_rule {                                                                     \
-		static constexpr auto keyword = LEXY_KEYWORD(#KW_NAME, lexy::dsl::inline_<Identifier>); \
-		static constexpr auto rule = keyword >> lexy::dsl::equal_sign;                          \
-		static constexpr auto value = lexy::noop;                                               \
-	};                                                                                          \
+#define OVDL_GRAMMAR_KEYWORD_DEFINE(KW_NAME)                                                                        \
+	struct KW_NAME##_rule {                                                                                         \
+		static constexpr auto keyword = LEXY_KEYWORD(#KW_NAME, lexy::dsl::inline_<Identifier<StringEscapeOption>>); \
+		static constexpr auto rule = keyword >> lexy::dsl::equal_sign;                                              \
+		static constexpr auto value = lexy::noop;                                                                   \
+	};                                                                                                              \
 	static constexpr auto KW_NAME##_p = lexy::dsl::p<KW_NAME##_rule>
 
 // Produces <KW_NAME>_rule and <KW_NAME>_p and <KW_NAME>_rule::flag and <KW_NAME>_rule::too_many_error
-#define OVDL_GRAMMAR_KEYWORD_FLAG_DEFINE(KW_NAME)                                               \
-	struct KW_NAME##_rule {                                                                     \
-		static constexpr auto keyword = LEXY_KEYWORD(#KW_NAME, lexy::dsl::inline_<Identifier>); \
-		static constexpr auto rule = keyword >> lexy::dsl::equal_sign;                          \
-		static constexpr auto value = lexy::noop;                                               \
-		static constexpr auto flag = lexy::dsl::context_flag<struct KW_NAME##_context>;         \
-		struct too_many_error {                                                                 \
-			static constexpr auto name = "expected left side " #KW_NAME " to be found once";    \
-		};                                                                                      \
-	};                                                                                          \
+#define OVDL_GRAMMAR_KEYWORD_FLAG_DEFINE(KW_NAME)                                                                   \
+	struct KW_NAME##_rule {                                                                                         \
+		static constexpr auto keyword = LEXY_KEYWORD(#KW_NAME, lexy::dsl::inline_<Identifier<StringEscapeOption>>); \
+		static constexpr auto rule = keyword >> lexy::dsl::equal_sign;                                              \
+		static constexpr auto value = lexy::noop;                                                                   \
+		static constexpr auto flag = lexy::dsl::context_flag<struct KW_NAME##_context>;                             \
+		struct too_many_error {                                                                                     \
+			static constexpr auto name = "expected left side " #KW_NAME " to be found once";                        \
+		};                                                                                                          \
+	};                                                                                                              \
 	static constexpr auto KW_NAME##_p = lexy::dsl::p<KW_NAME##_rule> >> (lexy::dsl::must(KW_NAME##_rule::flag.is_reset()).error<KW_NAME##_rule::too_many_error> + KW_NAME##_rule::flag.set())
 	//////////////////
 	// Macros
@@ -52,7 +52,7 @@ namespace ovdl::v2script::grammar {
 		OVDL_GRAMMAR_KEYWORD_DEFINE(months);
 
 		struct MonthValue {
-			static constexpr auto rule = lexy::dsl::inline_<Identifier>;
+			static constexpr auto rule = lexy::dsl::inline_<Identifier<StringEscapeOption>>;
 			static constexpr auto value = lexy::as_string<std::string> | lexy::new_<ast::MonthNode, ast::NodePtr>;
 		};
 
@@ -70,7 +70,7 @@ namespace ovdl::v2script::grammar {
 
 	template<auto Production, typename AstNode>
 	struct _StringStatement {
-		static constexpr auto rule = Production >> (lexy::dsl::p<StringExpression> | lexy::dsl::p<Identifier>);
+		static constexpr auto rule = Production >> (lexy::dsl::p<StringExpression<StringEscapeOption>> | lexy::dsl::p<Identifier<StringEscapeOption>>);
 		static constexpr auto value =
 			lexy::callback<ast::NodePtr>(
 				[](auto&& value) {
@@ -116,7 +116,7 @@ namespace ovdl::v2script::grammar {
 		OVDL_GRAMMAR_KEYWORD_DEFINE(option);
 
 		static constexpr auto rule = [] {
-			constexpr auto symbol_value = lexy::dsl::symbol<event_symbols>(lexy::dsl::inline_<Identifier>);
+			constexpr auto symbol_value = lexy::dsl::symbol<event_symbols>(lexy::dsl::inline_<Identifier<StringEscapeOption>>);
 
 			constexpr auto create_flags =
 				id_rule::flag.create() +
@@ -153,7 +153,7 @@ namespace ovdl::v2script::grammar {
 						   mean_time_to_happen_statement |
 						   trigger_statement |
 						   option_statement |
-						   lexy::dsl::p<SimpleAssignmentStatement>));
+						   lexy::dsl::p<SimpleAssignmentStatement<StringEscapeOption>>));
 		}();
 
 		static constexpr auto value =
@@ -171,7 +171,7 @@ namespace ovdl::v2script::grammar {
 		// Allow arbitrary spaces between individual tokens.
 		static constexpr auto whitespace = whitespace_specifier | comment_specifier;
 
-		static constexpr auto rule = lexy::dsl::terminator(lexy::dsl::eof).list(lexy::dsl::p<EventStatement> | lexy::dsl::p<SimpleAssignmentStatement>);
+		static constexpr auto rule = lexy::dsl::terminator(lexy::dsl::eof).list(lexy::dsl::p<EventStatement> | lexy::dsl::p<SimpleAssignmentStatement<StringEscapeOption>>);
 
 		static constexpr auto value = lexy::as_list<std::vector<ast::NodePtr>> >> lexy::new_<ast::FileNode, ast::NodePtr>;
 	};

--- a/src/openvic-dataloader/v2script/ModifierGrammar.hpp
+++ b/src/openvic-dataloader/v2script/ModifierGrammar.hpp
@@ -8,11 +8,11 @@
 #include "TriggerGrammar.hpp"
 
 namespace ovdl::v2script::grammar {
-	constexpr auto modifier_keyword = LEXY_KEYWORD("modifier", lexy::dsl::inline_<Identifier>);
-	constexpr auto factor_keyword = LEXY_KEYWORD("factor", lexy::dsl::inline_<Identifier>);
+	constexpr auto modifier_keyword = LEXY_KEYWORD("modifier", lexy::dsl::inline_<Identifier<StringEscapeOption>>);
+	constexpr auto factor_keyword = LEXY_KEYWORD("factor", lexy::dsl::inline_<Identifier<StringEscapeOption>>);
 
 	struct FactorStatement {
-		static constexpr auto rule = factor_keyword >> lexy::dsl::equal_sign + lexy::dsl::inline_<Identifier>;
+		static constexpr auto rule = factor_keyword >> lexy::dsl::equal_sign + lexy::dsl::inline_<Identifier<StringEscapeOption>>;
 		static constexpr auto value = lexy::as_string<std::string> | lexy::new_<ast::FactorNode, ast::NodePtr>;
 	};
 

--- a/src/openvic-dataloader/v2script/Parser.cpp
+++ b/src/openvic-dataloader/v2script/Parser.cpp
@@ -175,7 +175,7 @@ bool Parser::simple_parse() {
 		_warnings.push_back(warnings::make_utf8_warning(_file_path));
 	}
 
-	auto errors = _buffer_handler->parse<grammar::File>(ovdl::detail::ReporError.path(_file_path).to(detail::OStreamOutputIterator { _error_stream }));
+	auto errors = _buffer_handler->parse<grammar::File<grammar::NoStringEscapeOption>>(ovdl::detail::ReporError.path(_file_path).to(detail::OStreamOutputIterator { _error_stream }));
 	if (errors) {
 		_errors.reserve(errors->size());
 		for (auto& err : errors.value()) {

--- a/src/openvic-dataloader/v2script/TriggerGrammar.hpp
+++ b/src/openvic-dataloader/v2script/TriggerGrammar.hpp
@@ -9,7 +9,7 @@
 
 namespace ovdl::v2script::grammar {
 	struct TriggerStatement {
-		static constexpr auto rule = lexy::dsl::inline_<SimpleAssignmentStatement>;
+		static constexpr auto rule = lexy::dsl::inline_<SimpleAssignmentStatement<StringEscapeOption>>;
 
 		static constexpr auto value = lexy::callback<ast::NodePtr>(
 			[](auto name, auto&& initalizer) {
@@ -18,7 +18,7 @@ namespace ovdl::v2script::grammar {
 	};
 
 	struct TriggerList {
-		static constexpr auto rule = lexy::dsl::list(lexy::dsl::p<SimpleAssignmentStatement>);
+		static constexpr auto rule = lexy::dsl::list(lexy::dsl::p<SimpleAssignmentStatement<StringEscapeOption>>);
 
 		static constexpr auto value =
 			lexy::as_list<std::vector<ast::NodePtr>> >>


### PR DESCRIPTION
NoEscapeString to true to prevent escape behavior in strings

Event and Decision grammars use string escaping (for now)

Update lexy to latest master: Use `git submodule update --init --recursive`