### PR TITLE
StatementListBlocks no longer require key = {...}

### DIFF
--- a/src/openvic-dataloader/v2script/SimpleGrammar.hpp
+++ b/src/openvic-dataloader/v2script/SimpleGrammar.hpp
@@ -135,7 +135,8 @@ namespace ovdl::v2script::grammar {
 				(lexy::dsl::equal_sign >>
 						(lexy::dsl::p<ValueExpression<Options>> | lexy::dsl::recurse_branch<StatementListBlock<Options>>) |
 					lexy::dsl::else_ >> lexy::dsl::return_) |
-			lexy::dsl::p<StringExpression<Options>>;
+			lexy::dsl::p<StringExpression<Options>> |
+			lexy::dsl::recurse_branch<StatementListBlock<Options>>;
 
 		static constexpr auto value = lexy::callback<ast::NodePtr>(
 			[](const char* pos, auto name, lexy::nullopt = {}) {


### PR DESCRIPTION
Some files contain nested lists, so `{ { ... } }`, which didn't work before due to lists needing to be part of a `key = { ... }` assign statement.