### PR TITLE
Add grammar support for BEL, HT, LF, and CR characters

### DIFF
--- a/include/openvic-dataloader/v2script/AbstractSyntaxTree.hpp
+++ b/include/openvic-dataloader/v2script/AbstractSyntaxTree.hpp
@@ -166,9 +166,9 @@ namespace ovdl::v2script::ast {
 	struct AbstractStringNode : public Node {
 		std::string _name;
 		AbstractStringNode();
-		AbstractStringNode(std::string&& name);
+		AbstractStringNode(std::string&& name, bool allow_newline);
 		AbstractStringNode(NodeLocation location);
-		AbstractStringNode(NodeLocation location, std::string&& name);
+		AbstractStringNode(NodeLocation location, std::string&& name, bool allow_newline);
 		OVDL_TYPE_DEFINE_SELF;
 		OVDL_RT_TYPE_DEF;
 		OVDL_PRINT_FUNC_DEF;
@@ -176,17 +176,17 @@ namespace ovdl::v2script::ast {
 		constexpr std::string_view get_base_type() const override { return ::ovdl::detail::type_name<std::decay_t<decltype(*this)>>(); }
 	};
 
-#define OVDL_AST_STRING_NODE(NAME)                       \
-	struct NAME final : public AbstractStringNode {      \
-		NAME();                                          \
-		NAME(std::string&& name);                        \
-		NAME(lexy::nullopt);                             \
-		NAME(NodeLocation location);                     \
-		NAME(NodeLocation location, std::string&& name); \
-		NAME(NodeLocation location, lexy::nullopt);      \
-		OVDL_TYPE_DEFINE_SELF;                           \
-		OVDL_RT_TYPE_DEF;                                \
-		OVDL_PRINT_FUNC_DEF;                             \
+#define OVDL_AST_STRING_NODE(NAME)                                                  \
+	struct NAME final : public AbstractStringNode {                                 \
+		NAME();                                                                     \
+		NAME(std::string&& name, bool allow_newline = true);                        \
+		NAME(lexy::nullopt);                                                        \
+		NAME(NodeLocation location);                                                \
+		NAME(NodeLocation location, std::string&& name, bool allow_newline = true); \
+		NAME(NodeLocation location, lexy::nullopt);                                 \
+		OVDL_TYPE_DEFINE_SELF;                                                      \
+		OVDL_RT_TYPE_DEF;                                                           \
+		OVDL_PRINT_FUNC_DEF;                                                        \
 	}
 
 	// Value Expression Nodes

--- a/src/openvic-dataloader/v2script/SimpleGrammar.hpp
+++ b/src/openvic-dataloader/v2script/SimpleGrammar.hpp
@@ -83,12 +83,13 @@ namespace ovdl::v2script::grammar {
 	template<ParseOptions Options>
 	struct StringExpression {
 		static constexpr auto rule = [] {
-			// Arbitrary code points that aren't control characters.
-			auto c = ovdl::detail::lexydsl::make_range<0x20, 0xFF>() - lexy::dsl::ascii::control;
-
 			if constexpr (Options.NoStringEscape) {
+				auto c = ovdl::detail::lexydsl::make_range<0x20, 0xFF>() / lexy::dsl::lit_b<0x07> / lexy::dsl::lit_b<0x09> / lexy::dsl::lit_b<0x0A> / lexy::dsl::lit_b<0x0D>;
 				return lexy::dsl::delimited(lexy::dsl::position(lexy::dsl::lit_b<'"'>))(c);
 			} else {
+				// Arbitrary code points that aren't control characters.
+				auto c = ovdl::detail::lexydsl::make_range<0x20, 0xFF>() - lexy::dsl::ascii::control;
+
 				// Escape sequences start with a backlash.
 				// They either map one of the symbols,
 				// or a Unicode code point of the form uXXXX.
@@ -102,7 +103,7 @@ namespace ovdl::v2script::grammar {
 			lexy::as_string<std::string> >>
 			lexy::callback<ast::NodePtr>(
 				[](const char* begin, auto&& str, const char* end) {
-					return ast::make_node_ptr<ast::StringNode>(ast::NodeLocation::make_from(begin, end), LEXY_MOV(str));
+					return ast::make_node_ptr<ast::StringNode>(ast::NodeLocation::make_from(begin, end), LEXY_MOV(str), Options.NoStringEscape);
 				});
 	};
 


### PR DESCRIPTION
Add stripping of LF and CR characters if `v2script::grammar::StringExpression`'s `Options::NoStringEscape` is false