### PR TITLE
Expanded v2script character list to support Windows-1251

### DIFF
--- a/src/openvic-dataloader/v2script/SimpleGrammar.hpp
+++ b/src/openvic-dataloader/v2script/SimpleGrammar.hpp
@@ -43,7 +43,7 @@ namespace ovdl::v2script::grammar {
 	 * DAT-632
 	 * DAT-635
 	 */
-	static constexpr auto data_specifier =
+	static constexpr auto windows_1252_data_specifier =
 		lexy::dsl::ascii::alpha_digit_underscore / LEXY_ASCII_ONE_OF("+:@%&'-.") /
 		lexy::dsl::lit_b<0x8A> / lexy::dsl::lit_b<0x8C> / lexy::dsl::lit_b<0x8E> /
 		lexy::dsl::lit_b<0x92> / lexy::dsl::lit_b<0x97> / lexy::dsl::lit_b<0x9A> / lexy::dsl::lit_b<0x9C> /
@@ -51,6 +51,17 @@ namespace ovdl::v2script::grammar {
 		detail::lexydsl::make_range<0xC0, 0xD6>() /
 		detail::lexydsl::make_range<0xD8, 0xF6>() /
 		detail::lexydsl::make_range<0xF8, 0xFF>();
+
+	static constexpr auto windows_1251_data_specifier_additions =
+		detail::lexydsl::make_range<0x80, 0x81>() / lexy::dsl::lit_b<0x83> / lexy::dsl::lit_b<0x8D> / lexy::dsl::lit_b<0x8F> /
+		lexy::dsl::lit_b<0x90> / lexy::dsl::lit_b<0x9D> / lexy::dsl::lit_b<0x9F> /
+		detail::lexydsl::make_range<0xA1, 0xA3>() / lexy::dsl::lit_b<0xA5> / lexy::dsl::lit_b<0xA8> / lexy::dsl::lit_b<0xAA> /
+		lexy::dsl::lit_b<0xAF> /
+		detail::lexydsl::make_range<0xB2, 0xB4>() / lexy::dsl::lit_b<0xB8> / lexy::dsl::lit_b<0xBA> /
+		detail::lexydsl::make_range<0xBC, 0xBF>() /
+		lexy::dsl::lit_b<0xD7> / lexy::dsl::lit_b<0xF7>;
+
+	static constexpr auto data_specifier = windows_1252_data_specifier / windows_1251_data_specifier_additions;
 
 	static constexpr auto data_char_class = LEXY_CHAR_CLASS("DataSpecifier", data_specifier);
 


### PR DESCRIPTION
Marked current v2script parser identifier characters/data specifier as being for the [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252) character encoding, and added an additional specifier containing the characters needed to support [Windows-1251](https://en.wikipedia.org/wiki/Windows-1251). The final `data_specifier` is the union of these two sets, as what we need to support Windows-1251 is a strict superset of what we need to support Windows-1252.

This is a minimal PR just to stop the parser failing for Windows-1251 files, a more permanent solution would be dynamically detecting encoding and converting all parsed data to UTF-8. It might also be useful to designate more clearly what the different groups of non-ASCII characters we allow for encoding are, i.e. non-English letters vs punctuation.

The Windows-1251 additions sheet in [this document](https://docs.google.com/spreadsheets/d/1lFMFLPbH-x-Ut3jH5N8-t39k3EfZbIJQvRdEok0YF5M/edit?usp=sharing) marks which non-ASCII characters were already allowed for Windows-1252 parsing and which have been added by this PR for Windows-1251 parsing. It also marks some characters as suggested additions, all punctuation marks that are similar to already allowed characters and could reasonably appear in names or localised text: `‘ ‚ “ ” „`, which are similar to `’`, which is already allowed, and `‹ › « »`, which are European versions of quotation marks.

This PR does not make any changes to the Windows-1252 CSV parser as that does not seem to have an explicit list of allowed characters in the same way as v2script identifiers/data do.