### PR TITLE
Fixed BasicParser::_file_path relying on externally controlled memory

### DIFF
--- a/include/openvic-dataloader/csv/LineObject.hpp
+++ b/include/openvic-dataloader/csv/LineObject.hpp
@@ -88,7 +88,7 @@ namespace ovdl::csv {
 	};
 
 	inline std::ostream& operator<<(std::ostream& stream, const LineObject& line) {
-		static const char SEP = ';';
+		static constexpr char SEP = ';';
 		LineObject::position_type sep_index = 0;
 		for (const auto& [pos, val] : line) {
 			while (sep_index < pos) {

--- a/include/openvic-dataloader/detail/BasicParser.hpp
+++ b/include/openvic-dataloader/detail/BasicParser.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include <openvic-dataloader/ParseError.hpp>
@@ -22,13 +24,14 @@ namespace ovdl::detail {
 
 		const std::vector<ParseError>& get_errors() const;
 		const std::vector<ParseWarning>& get_warnings() const;
+		std::string_view get_file_path() const;
 
 	protected:
 		std::vector<ParseError> _errors;
 		std::vector<ParseWarning> _warnings;
 
 		std::reference_wrapper<std::ostream> _error_stream;
-		const char* _file_path;
+		std::string _file_path;
 		bool _has_fatal_error = false;
 	};
 }

--- a/src/openvic-dataloader/detail/BasicParser.cpp
+++ b/src/openvic-dataloader/detail/BasicParser.cpp
@@ -45,3 +45,7 @@ const std::vector<ovdl::ParseError>& BasicParser::get_errors() const {
 const std::vector<ovdl::ParseWarning>& BasicParser::get_warnings() const {
 	return _warnings;
 }
+
+std::string_view BasicParser::get_file_path() const {
+	return _file_path;
+}

--- a/src/openvic-dataloader/detail/Errors.hpp
+++ b/src/openvic-dataloader/detail/Errors.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <string_view>
+
 #include <openvic-dataloader/ParseError.hpp>
 
 namespace ovdl::errors {
-	inline const ParseError make_no_file_error(const char* file_path) {
+	inline const ParseError make_no_file_error(std::string_view file_path) {
 		std::string message;
-		if (!file_path) {
+		if (file_path.empty()) {
 			message = "File path not specified.";
 		} else {
 			message = "File '" + std::string(file_path) + "' was not found.";

--- a/src/openvic-dataloader/detail/LexyReportError.hpp
+++ b/src/openvic-dataloader/detail/LexyReportError.hpp
@@ -7,6 +7,7 @@
 
 #include <openvic-dataloader/ParseData.hpp>
 #include <openvic-dataloader/ParseError.hpp>
+#include <openvic-dataloader/detail/Concepts.hpp>
 
 #include <lexy/input_location.hpp>
 #include <lexy/visualize.hpp>
@@ -83,6 +84,10 @@ namespace ovdl::detail {
 		/// Specifies a path that will be printed alongside the diagnostic.
 		constexpr _ReportError path(const char* path) const {
 			return { _iter, _opts, path };
+		}
+
+		constexpr _ReportError path(const detail::Has_c_str auto& path_object) const {
+			return path(path_object.c_str());
 		}
 
 		/// Specifies an output iterator where the errors are written to.

--- a/src/openvic-dataloader/detail/Warnings.hpp
+++ b/src/openvic-dataloader/detail/Warnings.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <openvic-dataloader/v2script/Parser.hpp>
+#include <string_view>
+
+#include <openvic-dataloader/ParseWarning.hpp>
 
 namespace ovdl::v2script::warnings {
-	inline const ParseWarning make_utf8_warning(const char* file_path) {
+	inline const ParseWarning make_utf8_warning(std::string_view file_path) {
 		constexpr std::string_view message_suffix = "This may cause problems. Prefer Windows-1252 encoding.";
 
 		std::string message;
-		if (!file_path) {
+		if (file_path.empty()) {
 			message = "Buffer is a UTF-8 encoded string. " + std::string(message_suffix);
 		} else {
 			message = "File '" + std::string(file_path) + "' is a UTF-8 encoded file. " + std::string(message_suffix);

--- a/src/openvic-dataloader/v2script/Parser.cpp
+++ b/src/openvic-dataloader/v2script/Parser.cpp
@@ -273,7 +273,7 @@ const ast::Node::line_col Parser::get_node_end(const ast::NodeCPtr node) const {
 
 const ast::Node::line_col ast::Node::get_begin_line_col(const Parser& parser) const {
 	if (!parser._buffer_handler->is_valid() || parser._buffer_handler->_location_map.empty()) return {};
-	line_col result;
+	line_col result {};
 	auto [itr, range_end] = parser._buffer_handler->_location_map.equal_range(this);
 	if (itr != range_end) {
 		result.line = itr->second.line_nr();
@@ -293,7 +293,7 @@ const ast::Node::line_col ast::Node::get_begin_line_col(const Parser& parser) co
 
 const ast::Node::line_col ast::Node::get_end_line_col(const Parser& parser) const {
 	if (!parser._buffer_handler->is_valid() || parser._buffer_handler->_location_map.empty()) return {};
-	line_col result;
+	line_col result {};
 	auto [itr, range_end] = parser._buffer_handler->_location_map.equal_range(this);
 	if (itr != range_end) {
 		result.line = itr->second.line_nr();


### PR DESCRIPTION
`BasicParser` was storing its `_file_path` as a `const char*` to memory it had no control over, resulting in nonsense warnings when that memory had been freed. As an example, when parsing a v2script file with headless mode, `ovdl::v2script::Parser::from_file(path);` is called with `path` being `std::sting_view`. `path` is converted to a `std::filesystem::path` to be usable by `from_file`, and so the `Parser`'s `_file_path` refers to the memory of that temporary `std::filesystem::path` which has been destroyed by the time `Parser::simple_parse` is called and any warnings are created.

This PR changes `BasicParser::_file_path` to a `std::string`, adds a `BasicParser::get_file_path()` function, changes `make_no_file_error` and `make_utf8_warning` to accept a `std::string_view`, and allows `_ReportError::path` to accept a `c_str()`-having object.
It also makes two other minor changes: replacing a `static const char` with a `static constexpr char` and explicitly initialising two `line_col` variables as with MSVC these will not be default initialised and the rest of the functions are not guarunteed to modify them.