### PR TITLE
Add backslash identifier support to v2script

### DIFF
--- a/include/openvic-dataloader/csv/Parser.hpp
+++ b/include/openvic-dataloader/csv/Parser.hpp
@@ -42,6 +42,8 @@ namespace ovdl::csv {
 		using error_range = ovdl::detail::error_range<error::Root>;
 		Parser::error_range get_errors() const;
 
+		std::string_view error(const ovdl::error::Error* error) const;
+
 		const FilePosition get_error_position(const error::Error* error) const;
 
 		void print_errors_to(std::basic_ostream<char>& stream) const;

--- a/include/openvic-dataloader/v2script/Parser.hpp
+++ b/include/openvic-dataloader/v2script/Parser.hpp
@@ -61,6 +61,8 @@ namespace ovdl::v2script {
 		using error_range = ovdl::detail::error_range<error::Root>;
 		Parser::error_range get_errors() const;
 
+		std::string_view error(const ovdl::error::Error* error) const;
+
 		const FilePosition get_error_position(const error::Error* error) const;
 
 		void print_errors_to(std::basic_ostream<char>& stream) const;

--- a/src/openvic-dataloader/AbstractSyntaxTree.hpp
+++ b/src/openvic-dataloader/AbstractSyntaxTree.hpp
@@ -3,6 +3,7 @@
 #include <concepts>
 #include <cstdio>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 
 #include <openvic-dataloader/NodeLocation.hpp>
@@ -51,12 +52,12 @@ namespace ovdl {
 		using node_type = typename file_type::node_type;
 
 		explicit BasicAbstractSyntaxTree(file_type&& file)
-			: AbstractSyntaxTree(file.size()),
+			: AbstractSyntaxTree(file.size() * file.visit_buffer([](auto&& buffer) -> size_t { return sizeof(typename std::decay_t<decltype(buffer)>::char_type); })),
 			  _file { std::move(file) } {}
 
 		template<typename Encoding, typename MemoryResource = void>
 		explicit BasicAbstractSyntaxTree(lexy::buffer<Encoding, MemoryResource>&& buffer)
-			: AbstractSyntaxTree(buffer.size()),
+			: AbstractSyntaxTree(buffer.size() * sizeof(Encoding::char_type)),
 			  _file { std::move(buffer) } {}
 
 		void set_location(const node_type* n, NodeLocation loc) {

--- a/src/openvic-dataloader/csv/Parser.cpp
+++ b/src/openvic-dataloader/csv/Parser.cpp
@@ -195,6 +195,10 @@ typename Parser::error_range Parser::get_errors() const {
 	return _parse_handler->get_errors();
 }
 
+std::string_view Parser::error(const ovdl::error::Error* error) const {
+	return error->message(_parse_handler->parse_state().logger().symbol_interner());
+}
+
 const FilePosition Parser::get_error_position(const error::Error* error) const {
 	if (!error || !error->is_linked_in_tree()) {
 		return {};
@@ -231,20 +235,20 @@ void Parser::print_errors_to(std::basic_ostream<char>& stream) const {
 		dryad::visit_tree(
 			error,
 			[&](const error::BufferError* buffer_error) {
-				stream << "buffer error: " << buffer_error->message() << '\n';
+				stream << "buffer error: " << this->error(buffer_error) << '\n';
 			},
 			[&](dryad::child_visitor<error::ErrorKind> visitor, const error::AnnotatedError* annotated_error) {
-				stream << annotated_error->message() << '\n';
+				stream << this->error(annotated_error) << '\n';
 				auto annotations = annotated_error->annotations();
 				for (auto annotation : annotations) {
 					visitor(annotation);
 				}
 			},
 			[&](const error::PrimaryAnnotation* primary) {
-				stream << primary->message() << '\n';
+				stream << this->error(primary) << '\n';
 			},
 			[&](const error::SecondaryAnnotation* secondary) {
-				stream << secondary->message() << '\n';
+				stream << this->error(secondary) << '\n';
 			});
 	}
 }

--- a/src/openvic-dataloader/v2script/Parser.cpp
+++ b/src/openvic-dataloader/v2script/Parser.cpp
@@ -320,6 +320,10 @@ Parser::error_range Parser::get_errors() const {
 	return _parse_handler->get_errors();
 }
 
+std::string_view Parser::error(const ovdl::error::Error* error) const {
+	return error->message(_parse_handler->parse_state().logger().symbol_interner());
+}
+
 const FilePosition Parser::get_error_position(const error::Error* error) const {
 	if (!error || !error->is_linked_in_tree()) {
 		return {};
@@ -352,20 +356,20 @@ void Parser::print_errors_to(std::basic_ostream<char>& stream) const {
 		dryad::visit_tree(
 			error,
 			[&](const error::BufferError* buffer_error) {
-				stream << "buffer error: " << buffer_error->message() << '\n';
+				stream << "buffer error: " << this->error(buffer_error) << '\n';
 			},
 			[&](dryad::child_visitor<error::ErrorKind> visitor, const error::AnnotatedError* annotated_error) {
-				stream << annotated_error->message() << '\n';
+				stream << this->error(annotated_error) << '\n';
 				auto annotations = annotated_error->annotations();
 				for (auto annotation : annotations) {
 					visitor(annotation);
 				}
 			},
 			[&](const error::PrimaryAnnotation* primary) {
-				stream << primary->message() << '\n';
+				stream << this->error(primary) << '\n';
 			},
 			[&](const error::SecondaryAnnotation* secondary) {
-				stream << secondary->message() << '\n';
+				stream << this->error(secondary) << '\n';
 			});
 	}
 }


### PR DESCRIPTION
Add buffer::char_type size multiplier to max file size of string intern buffer

Fix list grammar segfaults
Fix diagnostic logger intern segfaults from buffer reallocation
Fix non-string-supported CSV parser not supporting Victoria 2 CSV escaping behavior