### PR TITLE
Create dependabot.yml file in dataloader.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "scripts"


### PR DESCRIPTION
Enables auto-opening PR for scripts propagation, will also catch vdf etc by default, but that's configured from each PR.