### PR TITLE
Simplify ANSI conversion

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -46,6 +46,8 @@ AlignTrailingComments: true
 AlignEscapedNewlines: Left
 AlignAfterOpenBracket: DontAlign
 AccessModifierOffset: -4
+Macros:
+  - "OVDL_DEFAULT_CASE_UNREACHABLE(OPTION)=default: ovdl::detail::unreachable()"
 IncludeCategories:
   - Regex: <[[:alnum:]_]+>
     Priority: 1

--- a/include/openvic-dataloader/detail/Encoding.hpp
+++ b/include/openvic-dataloader/detail/Encoding.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 
 namespace ovdl::detail {
-	enum class Encoding : std::int8_t {
+	enum class Encoding : std::uint8_t {
 		Unknown,
 		Ascii,
 		Utf8,

--- a/include/openvic-dataloader/detail/Utility.hpp
+++ b/include/openvic-dataloader/detail/Utility.hpp
@@ -7,6 +7,25 @@
 
 #include <openvic-dataloader/detail/Concepts.hpp>
 
+#ifdef DEBUG_ENABLED
+#define OVDL_DEFAULT_CASE_UNREACHABLE(...) \
+	__VA_OPT__(case __VA_ARGS__ : ovdl::detail::unreachable())
+#else
+#define OVDL_DEFAULT_CASE_UNREACHABLE(...) \
+	default: ovdl::detail::unreachable()
+#endif
+
+#ifdef __GNUC__
+#define OVDL_BEGIN_IGNORE_WARNING_RETURN_TYPE \
+	_Pragma("GCC diagnostic push")            \
+		_Pragma("GCC diagnostic ignored \"-Wreturn-type\"")
+#define OVDL_END_IGNORE_WARNING_RETURN_TYPE \
+	_Pragma("GCC diagnostic pop")
+#else
+#define OVDL_BEGIN_IGNORE_WARNING_RETURN_TYPE
+#define OVDL_END_IGNORE_WARNING_RETURN_TYPE
+#endif
+
 #if __has_cpp_attribute(msvc::no_unique_address)
 #define OVDL_NO_UNIQUE_ADDRESS                                  \
 	_Pragma("warning(push)") _Pragma("warning(disable : 4848)") \

--- a/src/openvic-dataloader/File.hpp
+++ b/src/openvic-dataloader/File.hpp
@@ -17,6 +17,7 @@ namespace ovdl {
 	struct File {
 		using buffer_ids = detail::TypeRegister<
 			lexy::buffer<lexy::default_encoding, void>,
+			lexy::buffer<lexy::ascii_encoding, void>,
 			lexy::buffer<lexy::utf8_char_encoding, void>,
 			lexy::buffer<lexy::utf8_encoding, void>,
 			lexy::buffer<lexy::utf16_encoding, void>,

--- a/src/openvic-dataloader/detail/Convert.hpp
+++ b/src/openvic-dataloader/detail/Convert.hpp
@@ -1,596 +1,421 @@
 #pragma once
 
+#include <concepts>
 #include <cstddef>
 #include <string_view>
 #include <type_traits>
 
 #include <lexy/_detail/config.hpp>
-#include <lexy/callback/string.hpp>
-#include <lexy/code_point.hpp>
-#include <lexy/dsl/option.hpp>
 #include <lexy/dsl/symbol.hpp>
 #include <lexy/encoding.hpp>
 #include <lexy/input/base.hpp>
+#include <lexy/input/buffer.hpp>
 #include <lexy/input/file.hpp>
-#include <lexy/input/string_input.hpp>
-#include <lexy/lexeme.hpp>
 
 #include "openvic-dataloader/detail/Encoding.hpp"
 
-#include "ParseState.hpp" // IWYU pragma: keep
-#include "detail/InternalConcepts.hpp"
-#include "detail/dsl.hpp"
-#include "v2script/ParseState.hpp"
-
 namespace ovdl::convert {
-	struct map_value {
-		std::string_view _value;
-
-		constexpr map_value() noexcept : _value("") {}
-		constexpr map_value(std::nullptr_t) noexcept : _value("\0", 1) {}
-		constexpr explicit map_value(std::string_view val) noexcept : _value(val) {}
-
-		static constexpr map_value invalid_value() noexcept {
-			return map_value(nullptr);
-		}
-
-		constexpr bool is_invalid() const noexcept {
-			return !_value.empty() && _value[0] == '\0';
-		}
-
-		constexpr bool is_pass() const noexcept {
-			return _value.empty();
-		}
-
-		constexpr bool is_valid() const noexcept {
-			return !_value.empty() && _value[0] != '\0';
-		}
-
-		constexpr explicit operator bool() const noexcept {
-			return is_valid();
-		}
-	};
-
 	template<typename T>
-	concept IsConverter = requires(unsigned char c, lexy::_pr<lexy::deduce_encoding<char>>& reader) {
-		{ T::try_parse(reader) } -> std::same_as<map_value>;
+	concept MapperConcept = requires(char* memory, detail::Encoding encoding) {
+		{ T::get_from(memory, encoding) } -> std::same_as<std::string_view>;
+		{ T::map(memory, encoding) } -> std::convertible_to<size_t>;
 	};
 
-	struct Utf8 {
-		static constexpr auto map = lexy::symbol_table<std::string_view>;
+	struct AnsiToUtf8Mapper {
+		static constexpr auto win1252_map = lexy::symbol_table<std::string_view> //
+												.map<'\x80'>("€")
+												.map<'\x82'>("‚")
+												.map<'\x83'>("ƒ")
+												.map<'\x84'>("„")
+												.map<'\x85'>("…")
+												.map<'\x86'>("†")
+												.map<'\x87'>("‡")
+												.map<'\x88'>("ˆ")
+												.map<'\x89'>("‰")
+												.map<'\x8A'>("Š")
+												.map<'\x8B'>("‹")
+												.map<'\x8C'>("Œ")
+												.map<'\x8E'>("Ž")
 
-		template<typename Reader>
-		static constexpr map_value try_parse(Reader& reader) {
-			return {};
-		}
-	};
-	static_assert(IsConverter<Utf8>);
+												.map<'\x91'>("‘")
+												.map<'\x92'>("’")
+												.map<'\x93'>("“")
+												.map<'\x94'>("”")
+												.map<'\x95'>("•")
+												.map<'\x96'>("–")
+												.map<'\x97'>("—")
+												.map<'\x98'>("˜")
+												.map<'\x99'>("™")
+												.map<'\x9A'>("š")
+												.map<'\x9B'>("›")
+												.map<'\x9C'>("œ")
+												.map<'\x9E'>("ž")
+												.map<'\x9F'>("Ÿ")
 
-	struct Windows1252 {
-		static constexpr auto map = lexy::symbol_table<std::string_view> //
-										.map<'\x80'>("€")
-										.map<'\x82'>("‚")
-										.map<'\x83'>("ƒ")
-										.map<'\x84'>("„")
-										.map<'\x85'>("…")
-										.map<'\x86'>("†")
-										.map<'\x87'>("‡")
-										.map<'\x88'>("ˆ")
-										.map<'\x89'>("‰")
-										.map<'\x8A'>("Š")
-										.map<'\x8B'>("‹")
-										.map<'\x8C'>("Œ")
-										.map<'\x8E'>("Ž")
+												.map<'\xA0'>(" ")
+												.map<'\xA1'>("¡")
+												.map<'\xA2'>("¢")
+												.map<'\xA3'>("£")
+												.map<'\xA4'>("¤")
+												.map<'\xA5'>("¥")
+												.map<'\xA6'>("¦")
+												.map<'\xA7'>("§")
+												.map<'\xA8'>("¨")
+												.map<'\xA9'>("©")
+												.map<'\xAA'>("ª")
+												.map<'\xAB'>("«")
+												.map<'\xAC'>("¬")
+												.map<'\xAD'>("­") // Soft Hyphen
+												.map<'\xAE'>("®")
+												.map<'\xAF'>("¯")
 
-										.map<'\x91'>("‘")
-										.map<'\x92'>("’")
-										.map<'\x93'>("“")
-										.map<'\x94'>("”")
-										.map<'\x95'>("•")
-										.map<'\x96'>("–")
-										.map<'\x97'>("—")
-										.map<'\x98'>("˜")
-										.map<'\x99'>("™")
-										.map<'\x9A'>("š")
-										.map<'\x9B'>("›")
-										.map<'\x9C'>("œ")
-										.map<'\x9E'>("ž")
-										.map<'\x9F'>("Ÿ")
+												.map<'\xB0'>("°")
+												.map<'\xB1'>("±")
+												.map<'\xB2'>("²")
+												.map<'\xB3'>("³")
+												.map<'\xB4'>("´")
+												.map<'\xB5'>("µ")
+												.map<'\xB6'>("¶")
+												.map<'\xB7'>("·")
+												.map<'\xB8'>("¸")
+												.map<'\xB9'>("¹")
+												.map<'\xBA'>("º")
+												.map<'\xBB'>("»")
+												.map<'\xBC'>("¼")
+												.map<'\xBD'>("½")
+												.map<'\xBE'>("¾")
+												.map<'\xBF'>("¿")
 
-										.map<'\xA0'>(" ")
-										.map<'\xA1'>("¡")
-										.map<'\xA2'>("¢")
-										.map<'\xA3'>("£")
-										.map<'\xA4'>("¤")
-										.map<'\xA5'>("¥")
-										.map<'\xA6'>("¦")
-										.map<'\xA7'>("§")
-										.map<'\xA8'>("¨")
-										.map<'\xA9'>("©")
-										.map<'\xAA'>("ª")
-										.map<'\xAB'>("«")
-										.map<'\xAC'>("¬")
-										.map<'\xAD'>("­") // Soft Hyphen
-										.map<'\xAE'>("®")
-										.map<'\xAF'>("¯")
+												.map<'\xC0'>("À")
+												.map<'\xC1'>("Á")
+												.map<'\xC2'>("Â")
+												.map<'\xC3'>("Ã")
+												.map<'\xC4'>("Ä")
+												.map<'\xC5'>("Å")
+												.map<'\xC6'>("Æ")
+												.map<'\xC7'>("Ç")
+												.map<'\xC8'>("È")
+												.map<'\xC9'>("É")
+												.map<'\xCA'>("Ê")
+												.map<'\xCB'>("Ë")
+												.map<'\xCC'>("Ì")
+												.map<'\xCD'>("Í")
+												.map<'\xCE'>("Î")
+												.map<'\xCF'>("Ï")
 
-										.map<'\xB0'>("°")
-										.map<'\xB1'>("±")
-										.map<'\xB2'>("²")
-										.map<'\xB3'>("³")
-										.map<'\xB4'>("´")
-										.map<'\xB5'>("µ")
-										.map<'\xB6'>("¶")
-										.map<'\xB7'>("·")
-										.map<'\xB8'>("¸")
-										.map<'\xB9'>("¹")
-										.map<'\xBA'>("º")
-										.map<'\xBB'>("»")
-										.map<'\xBC'>("¼")
-										.map<'\xBD'>("½")
-										.map<'\xBE'>("¾")
-										.map<'\xBF'>("¿")
+												.map<'\xD0'>("Ð")
+												.map<'\xD1'>("Ñ")
+												.map<'\xD2'>("Ò")
+												.map<'\xD3'>("Ó")
+												.map<'\xD4'>("Ô")
+												.map<'\xD5'>("Õ")
+												.map<'\xD6'>("Ö")
+												.map<'\xD7'>("×")
+												.map<'\xD8'>("Ø")
+												.map<'\xD9'>("Ù")
+												.map<'\xDA'>("Ú")
+												.map<'\xDB'>("Û")
+												.map<'\xDC'>("Ü")
+												.map<'\xDD'>("Ý")
+												.map<'\xDE'>("Þ")
+												.map<'\xDF'>("ß")
 
-										.map<'\xC0'>("À")
-										.map<'\xC1'>("Á")
-										.map<'\xC2'>("Â")
-										.map<'\xC3'>("Ã")
-										.map<'\xC4'>("Ä")
-										.map<'\xC5'>("Å")
-										.map<'\xC6'>("Æ")
-										.map<'\xC7'>("Ç")
-										.map<'\xC8'>("È")
-										.map<'\xC9'>("É")
-										.map<'\xCA'>("Ê")
-										.map<'\xCB'>("Ë")
-										.map<'\xCC'>("Ì")
-										.map<'\xCD'>("Í")
-										.map<'\xCE'>("Î")
-										.map<'\xCF'>("Ï")
+												.map<'\xE0'>("à")
+												.map<'\xE1'>("á")
+												.map<'\xE2'>("â")
+												.map<'\xE3'>("ã")
+												.map<'\xE4'>("ä")
+												.map<'\xE5'>("å")
+												.map<'\xE6'>("æ")
+												.map<'\xE7'>("ç")
+												.map<'\xE8'>("è")
+												.map<'\xE9'>("é")
+												.map<'\xEA'>("ê")
+												.map<'\xEB'>("ë")
+												.map<'\xEC'>("ì")
+												.map<'\xED'>("í")
+												.map<'\xEE'>("î")
+												.map<'\xEF'>("ï")
 
-										.map<'\xD0'>("Ð")
-										.map<'\xD1'>("Ñ")
-										.map<'\xD2'>("Ò")
-										.map<'\xD3'>("Ó")
-										.map<'\xD4'>("Ô")
-										.map<'\xD5'>("Õ")
-										.map<'\xD6'>("Ö")
-										.map<'\xD7'>("×")
-										.map<'\xD8'>("Ø")
-										.map<'\xD9'>("Ù")
-										.map<'\xDA'>("Ú")
-										.map<'\xDB'>("Û")
-										.map<'\xDC'>("Ü")
-										.map<'\xDD'>("Ý")
-										.map<'\xDE'>("Þ")
-										.map<'\xDF'>("ß")
+												.map<'\xF0'>("ð")
+												.map<'\xF1'>("ñ")
+												.map<'\xF2'>("ò")
+												.map<'\xF3'>("ó")
+												.map<'\xF4'>("ô")
+												.map<'\xF5'>("õ")
+												.map<'\xF6'>("ö")
+												.map<'\xF7'>("÷")
+												.map<'\xF8'>("ø")
+												.map<'\xF9'>("ù")
+												.map<'\xFA'>("ú")
+												.map<'\xFB'>("û")
+												.map<'\xFC'>("ü")
+												.map<'\xFD'>("ý")
+												.map<'\xFE'>("þ")
+												.map<'\xFF'>("ÿ")
 
-										.map<'\xE0'>("à")
-										.map<'\xE1'>("á")
-										.map<'\xE2'>("â")
-										.map<'\xE3'>("ã")
-										.map<'\xE4'>("ä")
-										.map<'\xE5'>("å")
-										.map<'\xE6'>("æ")
-										.map<'\xE7'>("ç")
-										.map<'\xE8'>("è")
-										.map<'\xE9'>("é")
-										.map<'\xEA'>("ê")
-										.map<'\xEB'>("ë")
-										.map<'\xEC'>("ì")
-										.map<'\xED'>("í")
-										.map<'\xEE'>("î")
-										.map<'\xEF'>("ï")
+												// Paradox being special, invalid Windows-1252
+												// Used for (semantically incorrect) Polish localization TODOs
+												.map<'\x8F'>("Ę");
 
-										.map<'\xF0'>("ð")
-										.map<'\xF1'>("ñ")
-										.map<'\xF2'>("ò")
-										.map<'\xF3'>("ó")
-										.map<'\xF4'>("ô")
-										.map<'\xF5'>("õ")
-										.map<'\xF6'>("ö")
-										.map<'\xF7'>("÷")
-										.map<'\xF8'>("ø")
-										.map<'\xF9'>("ù")
-										.map<'\xFA'>("ú")
-										.map<'\xFB'>("û")
-										.map<'\xFC'>("ü")
-										.map<'\xFD'>("ý")
-										.map<'\xFE'>("þ")
-										.map<'\xFF'>("ÿ")
+		static constexpr auto win1251_map = lexy::symbol_table<std::string_view> //
+												.map<'\x80'>("Ђ")
+												.map<'\x81'>("Ѓ")
+												.map<'\x82'>("‚")
+												.map<'\x83'>("ѓ")
+												.map<'\x84'>("„")
+												.map<'\x85'>("…")
+												.map<'\x86'>("†")
+												.map<'\x87'>("‡")
+												.map<'\x88'>("€")
+												.map<'\x89'>("‰")
+												.map<'\x8A'>("Љ")
+												.map<'\x8B'>("‹")
+												.map<'\x8C'>("Њ")
+												.map<'\x8D'>("Ќ")
+												.map<'\x8E'>("Ћ")
+												.map<'\x8F'>("Џ")
 
-										// Paradox being special, invalid Windows-1252
-										// Used for (semantically incorrect) Polish localization TODOs
-										.map<'\x8F'>("Ę");
+												.map<'\x90'>("ђ")
+												.map<'\x91'>("‘")
+												.map<'\x92'>("’")
+												.map<'\x93'>("“")
+												.map<'\x94'>("”")
+												.map<'\x95'>("•")
+												.map<'\x96'>("–")
+												.map<'\x97'>("—")
+												.map<'\x99'>("™")
+												.map<'\x9A'>("љ")
+												.map<'\x9B'>("›")
+												.map<'\x9C'>("њ")
+												.map<'\x9D'>("ќ")
+												.map<'\x9E'>("ћ")
+												.map<'\x9F'>("џ")
 
-		template<typename Reader>
-		static constexpr map_value try_parse(Reader& reader) {
-			auto index = map.try_parse(reader);
-			if (index) {
-				return map_value(map[index]);
-			} else if (*reader.position() < 0) {
-				return map_value::invalid_value();
+												.map<'\xA0'>(" ")
+												.map<'\xA1'>("Ў")
+												.map<'\xA2'>("ў")
+												.map<'\xA3'>("Ј")
+												.map<'\xA4'>("¤")
+												.map<'\xA5'>("Ґ")
+												.map<'\xA6'>("¦")
+												.map<'\xA7'>("§")
+												.map<'\xA8'>("Ё")
+												.map<'\xA9'>("©")
+												.map<'\xAA'>("Є")
+												.map<'\xAB'>("«")
+												.map<'\xAC'>("¬")
+												.map<'\xAD'>("­") // Soft Hyphen
+												.map<'\xAE'>("®")
+												.map<'\xAF'>("Ї")
+
+												.map<'\xB0'>("°")
+												.map<'\xB1'>("±")
+												.map<'\xB2'>("І")
+												.map<'\xB3'>("і")
+												.map<'\xB4'>("ґ")
+												.map<'\xB5'>("µ")
+												.map<'\xB6'>("¶")
+												.map<'\xB7'>("·")
+												.map<'\xB8'>("ё")
+												.map<'\xB9'>("№")
+												.map<'\xBA'>("є")
+												.map<'\xBB'>("»")
+												.map<'\xBC'>("ј")
+												.map<'\xBD'>("Ѕ")
+												.map<'\xBE'>("ѕ")
+												.map<'\xBF'>("ї")
+
+												.map<'\xC0'>("А")
+												.map<'\xC1'>("Б")
+												.map<'\xC2'>("В")
+												.map<'\xC3'>("Г")
+												.map<'\xC4'>("Д")
+												.map<'\xC5'>("Е")
+												.map<'\xC6'>("Ж")
+												.map<'\xC7'>("З")
+												.map<'\xC8'>("И")
+												.map<'\xC9'>("Й")
+												.map<'\xCA'>("К")
+												.map<'\xCB'>("Л")
+												.map<'\xCC'>("М")
+												.map<'\xCD'>("Н")
+												.map<'\xCE'>("О")
+												.map<'\xCF'>("П")
+
+												.map<'\xD0'>("Р")
+												.map<'\xD1'>("С")
+												.map<'\xD2'>("Т")
+												.map<'\xD3'>("У")
+												.map<'\xD4'>("Ф")
+												.map<'\xD5'>("Х")
+												.map<'\xD6'>("Ц")
+												.map<'\xD7'>("Ч")
+												.map<'\xD8'>("Ш")
+												.map<'\xD9'>("Щ")
+												.map<'\xDA'>("Ъ")
+												.map<'\xDB'>("Ы")
+												.map<'\xDC'>("Ь")
+												.map<'\xDD'>("Э")
+												.map<'\xDE'>("Ю")
+												.map<'\xDF'>("Я")
+
+												.map<'\xE0'>("а")
+												.map<'\xE1'>("б")
+												.map<'\xE2'>("в")
+												.map<'\xE3'>("г")
+												.map<'\xE4'>("д")
+												.map<'\xE5'>("е")
+												.map<'\xE6'>("ж")
+												.map<'\xE7'>("з")
+												.map<'\xE8'>("и")
+												.map<'\xE9'>("й")
+												.map<'\xEA'>("к")
+												.map<'\xEB'>("л")
+												.map<'\xEC'>("м")
+												.map<'\xED'>("н")
+												.map<'\xEE'>("о")
+												.map<'\xEF'>("п")
+
+												.map<'\xF0'>("р")
+												.map<'\xF1'>("с")
+												.map<'\xF2'>("т")
+												.map<'\xF3'>("у")
+												.map<'\xF4'>("ф")
+												.map<'\xF5'>("х")
+												.map<'\xF6'>("ц")
+												.map<'\xF7'>("ч")
+												.map<'\xF8'>("ш")
+												.map<'\xF9'>("щ")
+												.map<'\xFA'>("ъ")
+												.map<'\xFB'>("ы")
+												.map<'\xFC'>("ь")
+												.map<'\xFD'>("э")
+												.map<'\xFE'>("ю")
+												.map<'\xFF'>("я");
+
+		static std::string_view get_from(const char* memory, detail::Encoding encoding) {
+			auto reader = lexy::_range_reader<lexy::default_encoding>(memory, memory + 1);
+
+			switch (encoding) {
+				using enum detail::Encoding;
+				case Windows1251: {
+					auto index = win1251_map.try_parse(reader);
+					if (index) {
+						return win1251_map[index];
+					}
+				}
+				case Windows1252: {
+					auto index = win1252_map.try_parse(reader);
+					if (index) {
+						return win1252_map[index];
+					}
+					break;
+				}
+				default: break;
 			}
-			return {};
+			return { memory, 1 };
 		}
-	};
-	static_assert(IsConverter<Windows1252>);
 
-	struct Windows1251 {
-		static constexpr auto map = lexy::symbol_table<std::string_view> //
-										.map<'\x80'>("Ђ")
-										.map<'\x81'>("Ѓ")
-										.map<'\x82'>("‚")
-										.map<'\x83'>("ѓ")
-										.map<'\x84'>("„")
-										.map<'\x85'>("…")
-										.map<'\x86'>("†")
-										.map<'\x87'>("‡")
-										.map<'\x88'>("€")
-										.map<'\x89'>("‰")
-										.map<'\x8A'>("Љ")
-										.map<'\x8B'>("‹")
-										.map<'\x8C'>("Њ")
-										.map<'\x8D'>("Ќ")
-										.map<'\x8E'>("Ћ")
-										.map<'\x8F'>("Џ")
-
-										.map<'\x90'>("ђ")
-										.map<'\x91'>("‘")
-										.map<'\x92'>("’")
-										.map<'\x93'>("“")
-										.map<'\x94'>("”")
-										.map<'\x95'>("•")
-										.map<'\x96'>("–")
-										.map<'\x97'>("—")
-										.map<'\x99'>("™")
-										.map<'\x9A'>("љ")
-										.map<'\x9B'>("›")
-										.map<'\x9C'>("њ")
-										.map<'\x9D'>("ќ")
-										.map<'\x9E'>("ћ")
-										.map<'\x9F'>("џ")
-
-										.map<'\xA0'>(" ")
-										.map<'\xA1'>("Ў")
-										.map<'\xA2'>("ў")
-										.map<'\xA3'>("Ј")
-										.map<'\xA4'>("¤")
-										.map<'\xA5'>("Ґ")
-										.map<'\xA6'>("¦")
-										.map<'\xA7'>("§")
-										.map<'\xA8'>("Ё")
-										.map<'\xA9'>("©")
-										.map<'\xAA'>("Є")
-										.map<'\xAB'>("«")
-										.map<'\xAC'>("¬")
-										.map<'\xAD'>("­") // Soft Hyphen
-										.map<'\xAE'>("®")
-										.map<'\xAF'>("Ї")
-
-										.map<'\xB0'>("°")
-										.map<'\xB1'>("±")
-										.map<'\xB2'>("І")
-										.map<'\xB3'>("і")
-										.map<'\xB4'>("ґ")
-										.map<'\xB5'>("µ")
-										.map<'\xB6'>("¶")
-										.map<'\xB7'>("·")
-										.map<'\xB8'>("ё")
-										.map<'\xB9'>("№")
-										.map<'\xBA'>("є")
-										.map<'\xBB'>("»")
-										.map<'\xBC'>("ј")
-										.map<'\xBD'>("Ѕ")
-										.map<'\xBE'>("ѕ")
-										.map<'\xBF'>("ї")
-
-										.map<'\xC0'>("А")
-										.map<'\xC1'>("Б")
-										.map<'\xC2'>("В")
-										.map<'\xC3'>("Г")
-										.map<'\xC4'>("Д")
-										.map<'\xC5'>("Е")
-										.map<'\xC6'>("Ж")
-										.map<'\xC7'>("З")
-										.map<'\xC8'>("И")
-										.map<'\xC9'>("Й")
-										.map<'\xCA'>("К")
-										.map<'\xCB'>("Л")
-										.map<'\xCC'>("М")
-										.map<'\xCD'>("Н")
-										.map<'\xCE'>("О")
-										.map<'\xCF'>("П")
-
-										.map<'\xD0'>("Р")
-										.map<'\xD1'>("С")
-										.map<'\xD2'>("Т")
-										.map<'\xD3'>("У")
-										.map<'\xD4'>("Ф")
-										.map<'\xD5'>("Х")
-										.map<'\xD6'>("Ц")
-										.map<'\xD7'>("Ч")
-										.map<'\xD8'>("Ш")
-										.map<'\xD9'>("Щ")
-										.map<'\xDA'>("Ъ")
-										.map<'\xDB'>("Ы")
-										.map<'\xDC'>("Ь")
-										.map<'\xDD'>("Э")
-										.map<'\xDE'>("Ю")
-										.map<'\xDF'>("Я")
-
-										.map<'\xE0'>("а")
-										.map<'\xE1'>("б")
-										.map<'\xE2'>("в")
-										.map<'\xE3'>("г")
-										.map<'\xE4'>("д")
-										.map<'\xE5'>("е")
-										.map<'\xE6'>("ж")
-										.map<'\xE7'>("з")
-										.map<'\xE8'>("и")
-										.map<'\xE9'>("й")
-										.map<'\xEA'>("к")
-										.map<'\xEB'>("л")
-										.map<'\xEC'>("м")
-										.map<'\xED'>("н")
-										.map<'\xEE'>("о")
-										.map<'\xEF'>("п")
-
-										.map<'\xF0'>("р")
-										.map<'\xF1'>("с")
-										.map<'\xF2'>("т")
-										.map<'\xF3'>("у")
-										.map<'\xF4'>("ф")
-										.map<'\xF5'>("х")
-										.map<'\xF6'>("ц")
-										.map<'\xF7'>("ч")
-										.map<'\xF8'>("ш")
-										.map<'\xF9'>("щ")
-										.map<'\xFA'>("ъ")
-										.map<'\xFB'>("ы")
-										.map<'\xFC'>("ь")
-										.map<'\xFD'>("э")
-										.map<'\xFE'>("ю")
-										.map<'\xFF'>("я");
-
-		template<typename Reader>
-		static constexpr map_value try_parse(Reader& reader) {
-			auto index = map.try_parse(reader);
-			if (index) {
-				return map_value(map[index]);
-			} else if (*reader.position() < 0) {
-				return map_value::invalid_value();
+		static size_t map(char* memory, detail::Encoding encoding) {
+			if (std::string_view map = get_from(memory, encoding); !map.empty()) {
+				for (char const& c : map) {
+					*memory++ = c;
+				}
+				return map.size();
 			}
-			return {};
+			return 1;
 		}
 	};
-	static_assert(IsConverter<Windows1251>);
+	static_assert(MapperConcept<AnsiToUtf8Mapper>);
 
-	template<typename Reader>
-	constexpr map_value try_parse_map(detail::Encoding&& encoding, Reader& reader) {
-		switch (encoding) {
-			case detail::Encoding::Unknown:
-			case detail::Encoding::Ascii:
-			case detail::Encoding::Utf8: return Utf8::try_parse(reader);
-			case detail::Encoding::Windows1251: return Windows1251::try_parse(reader);
-			case detail::Encoding::Windows1252: return Windows1252::try_parse(reader);
+	constexpr auto ansi_to_utf8 = AnsiToUtf8Mapper {};
+
+	template<typename Encoding, MapperConcept Mapper, lexy::encoding_endianness Endian>
+	struct _make_buffer {
+		template<typename MemoryResource = void>
+		auto operator()(detail::Encoding encoding, const void* _memory, std::size_t size,
+			MemoryResource* resource = lexy::_detail::get_memory_resource<MemoryResource>()) const {
+			constexpr auto native_endianness = LEXY_IS_LITTLE_ENDIAN ? lexy::encoding_endianness::little : lexy::encoding_endianness::big;
+
+			using char_type = typename Encoding::char_type;
+			LEXY_PRECONDITION(size % sizeof(char_type) == 0);
+			auto memory = static_cast<const unsigned char*>(_memory);
+
+			if constexpr (sizeof(char_type) == 1 || Endian == native_endianness) {
+				switch (encoding) {
+					using enum detail::Encoding;
+					case Ascii:
+					case Utf8:
+						return lexy::make_buffer_from_raw<Encoding, Endian>(_memory, size, resource);
+					default: break;
+				}
+
+				size_t utf8_size = 0;
+				const auto end = memory + size;
+
+				for (auto dest = memory; dest != end; dest += sizeof(char_type)) {
+					utf8_size += Mapper::get_from(reinterpret_cast<const char_type*>(dest), encoding).size();
+				}
+
+				typename lexy::buffer<lexy::utf8_char_encoding, MemoryResource>::builder builder(utf8_size, resource);
+				for (auto dest = builder.data(); memory != end; memory += sizeof(char_type)) {
+					*dest = static_cast<char_type>(*memory);
+					dest += Mapper::map(dest, encoding);
+				}
+				return LEXY_MOV(builder).finish();
+			} else {
+				return lexy::make_buffer_from_raw<Encoding, Endian>(_memory, size, resource);
+			}
 		}
-		ovdl::detail::unreachable();
+	};
+
+	template<typename Encoding, MapperConcept Mapper = decltype(ansi_to_utf8), lexy::encoding_endianness Endianness = lexy::encoding_endianness::bom>
+	constexpr auto make_buffer_from_raw = _make_buffer<Encoding, Mapper, Endianness> {};
+
+	template<typename Encoding, lexy::encoding_endianness Endian, MapperConcept Mapper, typename MemoryResource>
+	struct _read_file_user_data : lexy::_read_file_user_data<Encoding, Endian, MemoryResource> {
+		using base_type = lexy::_read_file_user_data<Encoding, Endian, MemoryResource>;
+
+		detail::Encoding encoding;
+
+		_read_file_user_data(detail::Encoding encoding, MemoryResource* resource) : base_type(resource), encoding(encoding) {}
+		static auto callback() {
+			return [](void* _user_data, const char* memory, std::size_t size) {
+				auto user_data = static_cast<_read_file_user_data*>(_user_data);
+
+				user_data->buffer = make_buffer_from_raw<Encoding, Mapper, Endian>(user_data->encoding, memory, size, user_data->resource);
+			};
+		}
+	};
+
+	template<typename Encoding = lexy::default_encoding,
+		MapperConcept Mapper = decltype(ansi_to_utf8),
+		lexy::encoding_endianness Endian = lexy::encoding_endianness::bom,
+		typename MemoryResource = void>
+	auto read_file(
+		const char* path,
+		detail::Encoding encoding,
+		Mapper = {},
+		MemoryResource* resource = lexy::_detail::get_memory_resource<MemoryResource>())
+		-> lexy::read_file_result<Encoding, MemoryResource> {
+		_read_file_user_data<Encoding, Endian, Mapper, MemoryResource> user_data(encoding, resource);
+		auto error = lexy::_detail::read_file(path, user_data.callback(), &user_data);
+		return lexy::read_file_result(error, LEXY_MOV(user_data.buffer));
 	}
 
-	template<typename String>
-	using _string_char_type = LEXY_DECAY_DECLTYPE(LEXY_DECLVAL(String)[0]);
-
-	template<typename T, typename CharT>
-	concept IsErrorHandler =
-		std::is_convertible_v<CharT, char> //
-		&& requires(T t, ovdl::v2script::ast::ParseState& state, lexy::_pr<lexy::deduce_encoding<CharT>> reader) {
-			   { T::on_invalid_character(state, reader) };
-		   };
-
-	struct EmptyHandler {
-		static constexpr void on_invalid_character(detail::IsStateType auto& state, auto reader) {}
-	};
-
-	template<typename String,
-		IsErrorHandler<_string_char_type<String>> Error = EmptyHandler>
-	constexpr auto convert_as_string =
-		dsl::sink<String>(
-			lexy::fold_inplace<String>(
-				std::initializer_list<_string_char_type<String>> {}, //
-				[]<typename CharT, typename = decltype(LEXY_DECLVAL(String).push_back(CharT()))>(String& result, detail::IsStateType auto& state, CharT c) {
-					if constexpr (std::is_convertible_v<CharT, char>) {
-						switch (state.encoding()) {
-							using enum ovdl::detail::Encoding;
-							case Ascii:
-							case Utf8:
-								break;
-							// Skip Ascii and Utf8 encoding
-							default: {
-								// If within ASCII range
-								if (c >= CharT {}) {
-									break;
-								}
-
-								map_value val = {};
-								CharT char_array[] { c, CharT() };
-								auto input = lexy::range_input(&char_array[0], &char_array[1]);
-								auto reader = input.reader();
-
-								// prefer preserving unknown conversion maps, least things will work, they'll just probably display wrong
-								// map = make_map_from(state.encoding(), c);
-								val = try_parse_map(state.encoding(), reader);
-
-								// Invalid characters are dropped
-								if (val.is_invalid()) {
-									Error::on_invalid_character(state, reader);
-									return;
-								}
-
-								// non-pass characters are not valid ascii and are mapped to utf8 values
-								if (!val.is_pass()) {
-									result.append(val._value);
-									return;
-								}
-
-								break;
-							}
-						}
-					}
-
-					result.push_back(c); //
-				},						 //
-				[](String& result, detail::IsStateType auto& state, String&& str) {
-					if constexpr (std::is_convertible_v<typename String::value_type, char>) {
-						switch (state.encoding()) {
-							using enum ovdl::detail::Encoding;
-							case Ascii:
-							case Utf8:
-								break;
-							// Skip Ascii and Utf8 encoding
-							default: {
-								auto input = lexy::string_input(str);
-								auto reader = input.reader();
-								using encoding = decltype(reader)::encoding;
-								constexpr auto eof = encoding::eof();
-
-								if constexpr (requires { result.reserve(str.size()); }) {
-									result.reserve(str.size());
-								}
-
-								auto begin = reader.position();
-								auto last_it = begin;
-								while (reader.peek() != eof) {
-									// If not within ASCII range
-									if (*reader.position() < 0) {
-										map_value val = try_parse_map(state.encoding(), reader);
-
-										if (val.is_invalid()) {
-											Error::on_invalid_character(state, reader);
-											reader.bump();
-											continue;
-										} else if (!val.is_pass()) {
-											result.append(val._value);
-											last_it = reader.position();
-											continue;
-										}
-									}
-
-									while (reader.peek() != eof && *reader.position() > 0) {
-										reader.bump();
-									}
-									result.append(last_it, reader.position());
-									last_it = reader.position();
-								}
-								if (last_it != begin) {
-									return;
-								}
-								break;
-							}
-						}
-					}
-
-					result.append(LEXY_MOV(str));																							//
-				},																															//
-				[]<typename Str = String, typename Iterator>(String& result, detail::IsStateType auto& state, Iterator begin, Iterator end) //
-				-> decltype(void(LEXY_DECLVAL(Str).append(begin, end))) {
-					if constexpr (std::is_convertible_v<typename String::value_type, char>) {
-						switch (state.encoding()) {
-							using enum ovdl::detail::Encoding;
-							case Ascii:
-							case Utf8:
-								break;
-							// Skip Ascii and Utf8 encoding
-							default: {
-								auto input = lexy::range_input(begin, end);
-								auto reader = input.reader();
-								using encoding = decltype(reader)::encoding;
-								constexpr auto eof = encoding::eof();
-
-								if constexpr (requires { result.reserve(end - begin); }) {
-									result.reserve(end - begin);
-								}
-
-								auto begin = reader.position();
-								auto last_it = begin;
-								while (reader.peek() != eof) {
-									// If not within ASCII range
-									if (*reader.position() < 0) {
-										map_value val = try_parse_map(state.encoding(), reader);
-
-										if (val.is_invalid()) {
-											Error::on_invalid_character(state, reader);
-											reader.bump();
-											continue;
-										} else if (!val.is_pass()) {
-											result.append(val._value);
-											last_it = reader.position();
-											continue;
-										}
-									}
-
-									while (reader.peek() != eof && *reader.position() > 0) {
-										reader.bump();
-									}
-									result.append(last_it, reader.position());
-									last_it = reader.position();
-								}
-								if (last_it != begin) {
-									return;
-								}
-								break;
-							}
-						}
-					}
-
-					result.append(begin, end); //
-				},							   //
-				[]<typename Reader>(String& result, detail::IsStateType auto& state, lexy::lexeme<Reader> lex) {
-					using encoding = typename Reader::encoding;
-					using _char_type = _string_char_type<String>;
-					static_assert(lexy::char_type_compatible_with_reader<Reader, _char_type>,
-						"cannot convert lexeme to this string type");
-
-					if constexpr ((std::same_as<encoding, lexy::default_encoding> || std::same_as<encoding, lexy::byte_encoding>) &&
-								  std::convertible_to<typename String::value_type, char>) {
-						auto input = lexy::range_input(lex.begin(), lex.end());
-						auto reader = input.reader();
-						using encoding = decltype(reader)::encoding;
-						constexpr auto eof = encoding::eof();
-
-						if constexpr (requires { result.reserve(lex.end() - lex.begin()); }) {
-							result.reserve(lex.end() - lex.begin());
-						}
-
-						auto begin = reader.position();
-						auto last_it = begin;
-						while (reader.peek() != eof) {
-							// If not within ASCII range
-							if (*reader.position() < 0) {
-								map_value val = try_parse_map(state.encoding(), reader);
-
-								if (val.is_invalid()) {
-									Error::on_invalid_character(state, reader);
-									reader.bump();
-									continue;
-								} else if (!val.is_pass()) {
-									result.append(val._value);
-									last_it = reader.position();
-									continue;
-								}
-							}
-
-							while (reader.peek() != eof && *reader.position() > 0) {
-								reader.bump();
-							}
-							result.append(last_it, reader.position());
-							last_it = reader.position();
-						}
-						if (last_it != begin) {
-							return;
-						}
-					}
-
-					result.append(lex.begin(), lex.end()); //
-				}));
+	/// Reads stdin into a buffer.
+	template<typename Encoding = lexy::default_encoding,
+		MapperConcept Mapper = decltype(ansi_to_utf8),
+		lexy::encoding_endianness Endian = lexy::encoding_endianness::bom,
+		typename MemoryResource = void>
+	auto read_stdin(
+		detail::Encoding encoding,
+		Mapper = {},
+		MemoryResource* resource = lexy::_detail::get_memory_resource<MemoryResource>())
+		-> lexy::read_file_result<Encoding, MemoryResource> {
+		_read_file_user_data<Encoding, Endian, Mapper, MemoryResource> user_data(encoding, resource);
+		auto error = lexy::_detail::read_stdin(user_data.callback(), &user_data);
+		return lexy::read_file_result(error, LEXY_MOV(user_data.buffer));
+	}
 }

--- a/src/openvic-dataloader/v2script/DecisionGrammar.hpp
+++ b/src/openvic-dataloader/v2script/DecisionGrammar.hpp
@@ -26,13 +26,13 @@ namespace ovdl::v2script::grammar {
 		using helper = dsl::rule_helper<potential, allow, effect, ai_will_do>;
 
 		struct List {
-			static constexpr auto rule = dsl::curly_bracketed.opt_list(helper::p | lexy::dsl::p<SAssignStatement<StringEscapeOption>>);
+			static constexpr auto rule = dsl::curly_bracketed.opt_list(helper::p | lexy::dsl::p<SimpleAssignmentStatement>);
 
 			static constexpr auto value = lexy::as_list<ast::AssignStatementList> >> construct_list<ast::ListValue>;
 		};
 
 		static constexpr auto rule =
-			dsl::p<Identifier<StringEscapeOption>> >>
+			dsl::p<Identifier> >>
 			(helper::flags + lexy::dsl::equal_sign + lexy::dsl::p<List>);
 
 		static constexpr auto value = construct<ast::AssignStatement>;

--- a/src/openvic-dataloader/v2script/EffectGrammar.hpp
+++ b/src/openvic-dataloader/v2script/EffectGrammar.hpp
@@ -10,7 +10,7 @@
 
 namespace ovdl::v2script::grammar {
 	struct EffectStatement {
-		static constexpr auto rule = lexy::dsl::p<SAssignStatement<StringEscapeOption>>;
+		static constexpr auto rule = lexy::dsl::p<SimpleAssignmentStatement>;
 
 		static constexpr auto value = lexy::forward<ast::AssignStatement*>;
 	};

--- a/src/openvic-dataloader/v2script/EventGrammar.hpp
+++ b/src/openvic-dataloader/v2script/EventGrammar.hpp
@@ -26,7 +26,7 @@ namespace ovdl::v2script::grammar {
 
 	struct EventMtthStatement {
 		struct MonthValue {
-			static constexpr auto rule = lexy::dsl::p<Identifier<StringEscapeOption>>;
+			static constexpr auto rule = lexy::dsl::p<Identifier>;
 			static constexpr auto value = dsl::callback<ast::IdentifierValue*>(
 				[](detail::IsParseState auto& state, ast::IdentifierValue* value) {
 					bool is_number = true;
@@ -52,7 +52,7 @@ namespace ovdl::v2script::grammar {
 		static constexpr auto value = lexy::as_list<ast::AssignStatementList> >> construct_list<ast::ListValue, true>;
 	};
 
-	static constexpr auto str_or_id = lexy::dsl::p<SimpleGrammar<StringEscapeOption>::ValueExpression>;
+	static constexpr auto str_or_id = lexy::dsl::p<ValueExpression>;
 
 	struct EventOptionList {
 		using name = fkeyword_rule<"name", str_or_id>;
@@ -86,13 +86,13 @@ namespace ovdl::v2script::grammar {
 				return helper::flags +
 					   dsl::curly_bracketed.opt_list(
 						   helper::p | lexy::dsl::p<trigger> | lexy::dsl::p<option> |
-						   lexy::dsl::p<SAssignStatement<StringEscapeOption>>);
+						   lexy::dsl::p<SimpleAssignmentStatement>);
 			}();
 
 			static constexpr auto value = lexy::as_list<ast::AssignStatementList> >> construct_list<ast::ListValue, true>;
 		};
 
-		static constexpr auto rule = dsl::p<Identifier<StringEscapeOption>> >> lexy::dsl::equal_sign >> lexy::dsl::p<EventList>;
+		static constexpr auto rule = dsl::p<Identifier> >> lexy::dsl::equal_sign >> lexy::dsl::p<EventList>;
 
 		static constexpr auto value =
 			dsl::callback<ast::EventStatement*>(
@@ -114,7 +114,7 @@ namespace ovdl::v2script::grammar {
 		// Allow arbitrary spaces between individual tokens.
 		static constexpr auto whitespace = whitespace_specifier | comment_specifier;
 
-		static constexpr auto rule = lexy::dsl::position + lexy::dsl::terminator(lexy::dsl::eof).list(lexy::dsl::p<EventStatement> | lexy::dsl::p<SAssignStatement<StringEscapeOption>>);
+		static constexpr auto rule = lexy::dsl::position + lexy::dsl::terminator(lexy::dsl::eof).list(lexy::dsl::p<EventStatement> | lexy::dsl::p<SimpleAssignmentStatement>);
 
 		static constexpr auto value = lexy::as_list<ast::StatementList> >> construct<ast::FileTree>;
 	};

--- a/src/openvic-dataloader/v2script/ModifierGrammar.hpp
+++ b/src/openvic-dataloader/v2script/ModifierGrammar.hpp
@@ -17,7 +17,7 @@ namespace ovdl::v2script::grammar {
 	constexpr auto factor_keyword = LEXY_KEYWORD("factor", id);
 
 	struct FactorStatement {
-		static constexpr auto rule = lexy::dsl::position(factor_keyword) >> (lexy::dsl::equal_sign + lexy::dsl::p<Identifier<StringEscapeOption>>);
+		static constexpr auto rule = lexy::dsl::position(factor_keyword) >> (lexy::dsl::equal_sign + lexy::dsl::p<Identifier>);
 		static constexpr auto value = dsl::callback<ast::AssignStatement*>(
 			[](detail::IsParseState auto& state, NodeLocation loc, ast::IdentifierValue* value) {
 				auto* factor = state.ast().template create<ast::IdentifierValue>(loc, state.ast().intern("factor"));

--- a/src/openvic-dataloader/v2script/SimpleGrammar.hpp
+++ b/src/openvic-dataloader/v2script/SimpleGrammar.hpp
@@ -5,12 +5,17 @@
 
 #include <lexy/callback.hpp>
 #include <lexy/dsl.hpp>
+#include <lexy/dsl/code_point.hpp>
+#include <lexy/dsl/delimited.hpp>
+#include <lexy/dsl/integer.hpp>
+#include <lexy/dsl/literal.hpp>
+#include <lexy/dsl/position.hpp>
+#include <lexy/dsl/unicode.hpp>
 #include <lexy/encoding.hpp>
 #include <lexy/input/base.hpp>
 #include <lexy/input/buffer.hpp>
 #include <lexy/lexeme.hpp>
 
-#include "detail/Convert.hpp"
 #include "detail/InternalConcepts.hpp"
 #include "detail/dsl.hpp"
 
@@ -38,322 +43,173 @@ namespace ovdl::v2script::grammar {
 		}
 	};
 
-	template<typename String>
-	constexpr auto convert_as_string = convert::convert_as_string<String, ConvertErrorHandler>;
-
-	struct ParseOptions {
-		/// @brief Makes string parsing avoid string escapes
-		bool NoStringEscape;
-	};
-
-	static constexpr auto NoStringEscapeOption = ParseOptions { true };
-	static constexpr auto StringEscapeOption = ParseOptions { false };
-
 	/* REQUIREMENTS: DAT-630 */
 	static constexpr auto whitespace_specifier = lexy::dsl::ascii::blank / lexy::dsl::ascii::newline;
 	/* REQUIREMENTS: DAT-631 */
 	static constexpr auto comment_specifier = LEXY_LIT("#") >> lexy::dsl::until(lexy::dsl::newline).or_eof();
 
-	static constexpr auto ascii = lexy::dsl::ascii::alpha_digit_underscore / LEXY_ASCII_ONE_OF("+:@%&'-.\\/");
-
 	/* REQUIREMENTS:
 	 * DAT-632
 	 * DAT-635
 	 */
-	static constexpr auto windows_1252_data_specifier =
-		ascii /
-		lexy::dsl::lit_b<0x8A> / lexy::dsl::lit_b<0x8C> / lexy::dsl::lit_b<0x8E> /
-		lexy::dsl::lit_b<0x92> / lexy::dsl::lit_b<0x97> / lexy::dsl::lit_b<0x9A> / lexy::dsl::lit_b<0x9C> /
-		dsl::lit_b_range<0x9E, 0x9F> /
-		dsl::lit_b_range<0xC0, 0xD6> /
-		dsl::lit_b_range<0xD8, 0xF6> /
-		dsl::lit_b_range<0xF8, 0xFF>;
-
-	static constexpr auto windows_1251_data_specifier_additions =
-		dsl::lit_b_range<0x80, 0x81> / lexy::dsl::lit_b<0x83> / lexy::dsl::lit_b<0x8D> / lexy::dsl::lit_b<0x8F> /
-		lexy::dsl::lit_b<0x90> / lexy::dsl::lit_b<0x9D> / lexy::dsl::lit_b<0x9F> /
-		dsl::lit_b_range<0xA1, 0xA3> / lexy::dsl::lit_b<0xA5> / lexy::dsl::lit_b<0xA8> / lexy::dsl::lit_b<0xAA> /
-		lexy::dsl::lit_b<0xAF> /
-		dsl::lit_b_range<0xB2, 0xB4> / lexy::dsl::lit_b<0xB8> / lexy::dsl::lit_b<0xBA> /
-		dsl::lit_b_range<0xBC, 0xBF> /
-		lexy::dsl::lit_b<0xD7> / lexy::dsl::lit_b<0xF7>;
-
-	static constexpr auto data_specifier = windows_1252_data_specifier / windows_1251_data_specifier_additions;
-
-	static constexpr auto data_char_class = LEXY_CHAR_CLASS("DataSpecifier", data_specifier);
-
-	static constexpr auto utf_data_specifier = lexy::dsl::unicode::xid_continue / LEXY_ASCII_ONE_OF("+:@%&'-.\\/");
+	static constexpr auto utf_data_specifier =
+		lexy::dsl::unicode::xid_continue / LEXY_ASCII_ONE_OF("+:@%&'-.\\/") /
+		lexy::dsl::code_point.range<U'À', U'Ö'>() /
+		lexy::dsl::code_point.range<U'Ø', U'ö'>() /
+		lexy::dsl::code_point.range<U'ø', U'ÿ'>() /
+		lexy::dsl::code_point.set<U'Š', U'Œ', U'Ž', U'’', U'—', U'š', U'œ', U'ž', U'Ÿ'>() /
+		lexy::dsl::code_point.set<U'Ђ', U'Ѓ', U'ѓ', U'Ќ', U'Џ', U'ђ', U'ќ', U'џ'>() /
+		lexy::dsl::code_point.set<U'Ў', U'ў', U'Ј', U'Ґ', U'Ё', U'Є', U'Ї', U'І'>() /
+		lexy::dsl::code_point.set<U'і', U'ґ', U'ё', U'є', U'ј', U'Ѕ', U'ѕ', U'ї'>() /
+		lexy::dsl::code_point.set<U'Ч', U'ч'>();
 
 	static constexpr auto utf_char_class = LEXY_CHAR_CLASS("DataSpecifier", utf_data_specifier);
 
-	static constexpr auto escaped_symbols = lexy::symbol_table<char> //
-												.map<'"'>('"')
-												.map<'\''>('\'')
-												.map<'\\'>('\\')
-												.map<'/'>('/')
-												.map<'b'>('\b')
-												.map<'f'>('\f')
-												.map<'n'>('\n')
-												.map<'r'>('\r')
-												.map<'t'>('\t');
+	static constexpr auto id = lexy::dsl::identifier(utf_char_class);
 
-	static constexpr auto id = lexy::dsl::identifier(ascii);
+	struct StatementListBlock;
 
-	template<ParseOptions Options>
-	struct SimpleGrammar {
-		struct StatementListBlock;
+	struct Identifier : lexy::token_production {
+		static constexpr auto rule = lexy::dsl::identifier(utf_char_class);
 
-		struct Identifier : lexy::scan_production<ast::IdentifierValue*>,
-							lexy::token_production {
-
-			template<typename Context, typename Reader>
-			static constexpr scan_result scan(lexy::rule_scanner<Context, Reader>& scanner, detail::IsParseState auto& state) {
-				using encoding = typename Reader::encoding;
-				using char_type = typename encoding::char_type;
-
-				std::basic_string<char_type> value_result;
-
-				auto content_begin = scanner.position();
-				do {
-					if constexpr (std::same_as<encoding, lexy::default_encoding> || std::same_as<encoding, lexy::byte_encoding>) {
-						if (lexy::scan_result<lexy::lexeme<Reader>> ascii_result; scanner.branch(ascii_result, lexy::dsl::identifier(ascii))) {
-							if (!scanner.peek(data_char_class)) {
-								if (ascii_result.value().size() == 0) {
-									return lexy::scan_failed;
-								}
-
-								auto value = state.ast().intern(ascii_result.value());
-								return state.ast().template create<ast::IdentifierValue>(ovdl::NodeLocation::make_from(content_begin, scanner.position()), value);
-							}
-
-							value_result.append(ascii_result.value().begin(), ascii_result.value().end());
-							continue;
-						}
-
-						char_type char_array[] { *scanner.position(), char_type {} };
-						auto input = lexy::range_input(&char_array[0], &char_array[1]);
-						auto reader = input.reader();
-						convert::map_value val = convert::try_parse_map(state.encoding(), reader);
-
-						if (val.is_invalid()) {
-							ConvertErrorHandler::on_invalid_character(state, reader);
-							continue;
-						}
-
-						if (!val.is_pass()) {
-							// non-pass characters are not valid ascii and are mapped to utf8 values
-							value_result.append(val._value);
-							scanner.parse(data_char_class);
-						} else {
-							break;
-						}
-					} else {
-						auto lexeme_result = scanner.template parse<lexy::lexeme<Reader>>(lexy::dsl::identifier(utf_char_class));
-						if (lexeme_result) {
-							if (lexeme_result.value().size() == 0) {
-								return lexy::scan_failed;
-							}
-
-							auto value = state.ast().intern(lexeme_result.value());
-							return state.ast().template create<ast::IdentifierValue>(ovdl::NodeLocation::make_from(content_begin, scanner.position()), value);
-						}
-					}
-				} while (scanner);
-				auto content_end = scanner.position();
-
-				if (value_result.empty()) {
-					return lexy::scan_failed;
-				}
-
-				auto value = state.ast().intern(value_result);
-				return state.ast().template create<ast::IdentifierValue>(ovdl::NodeLocation::make_from(content_begin, content_end), value);
-			}
-
-			static constexpr auto rule = dsl::peek(data_char_class, utf_char_class) >> lexy::dsl::scan;
-		};
-
-		/* REQUIREMENTS:
-		 * DAT-633
-		 * DAT-634
-		 */
-		struct StringExpression : lexy::scan_production<ast::StringValue*>,
-								  lexy::token_production {
-
-			template<typename Context, typename Reader>
-			static constexpr scan_result scan(lexy::rule_scanner<Context, Reader>& scanner, detail::IsParseState auto& state) {
-				using encoding = typename Reader::encoding;
-
-				constexpr auto rule = [] {
-					if constexpr (Options.NoStringEscape) {
-						auto c = [] {
-							if constexpr (std::same_as<encoding, lexy::default_encoding> || std::same_as<encoding, lexy::byte_encoding>) {
-								return dsl::lit_b_range<0x01, 0xFF>;
-							} else {
-								return lexy::dsl::unicode::character;
-							}
-						}();
-						return lexy::dsl::quoted(c);
-					} else {
-						// Arbitrary code points that aren't control characters.
-						auto c = [] {
-							if constexpr (std::same_as<encoding, lexy::default_encoding> || std::same_as<encoding, lexy::byte_encoding>) {
-								return dsl::lit_b_range<0x20, 0xFF> - lexy::dsl::ascii::control;
-							} else {
-								return -lexy::dsl::unicode::control;
-							}
-						}();
-
-						// Escape sequences start with a backlash.
-						// They either map one of the symbols,
-						// or a Unicode code point of the form uXXXX.
-						auto escape = lexy::dsl::backslash_escape //
-										  .symbol<escaped_symbols>();
-						return lexy::dsl::quoted(c, escape);
-					}
-				}();
-
-				auto begin = scanner.position();
-				lexy::scan_result<std::string> str_result;
-				scanner.parse(str_result, rule);
-				if (!scanner || !str_result) {
-					return lexy::scan_failed;
-				}
-				auto end = scanner.position();
-				auto str = str_result.value();
-				auto value = state.ast().intern(str.data(), str.size());
-				return state.ast().template create<ast::StringValue>(ovdl::NodeLocation::make_from(begin, end), value);
-			}
-
-			static constexpr auto rule = lexy::dsl::peek(lexy::dsl::quoted.open()) >> lexy::dsl::scan;
-			static constexpr auto value = convert_as_string<std::string> >> lexy::forward<ast::StringValue*>;
-		};
-
-		/* REQUIREMENTS: DAT-638 */
-		struct ValueExpression {
-			static constexpr auto rule = lexy::dsl::p<Identifier> | lexy::dsl::p<StringExpression>;
-			static constexpr auto value = lexy::forward<ast::Value*>;
-		};
-
-		struct SimpleAssignmentStatement {
-			static constexpr auto rule = [] {
-				auto right_brace = lexy::dsl::lit_c<'}'>;
-
-				auto value_expression = lexy::dsl::p<ValueExpression>;
-				auto statement_list_expression = lexy::dsl::recurse_branch<StatementListBlock>;
-
-				auto rhs_recover = lexy::dsl::recover(value_expression, statement_list_expression).limit(right_brace);
-				auto rhs_try = lexy::dsl::try_(value_expression | statement_list_expression, rhs_recover);
-
-				auto identifier =
-					dsl::p<Identifier> >>
-					(lexy::dsl::equal_sign >> rhs_try);
-
-				auto recover = lexy::dsl::recover(identifier).limit(right_brace);
-				return lexy::dsl::try_(identifier, recover);
-			}();
-
-			static constexpr auto value = construct<ast::AssignStatement>;
-		};
-
-		/* REQUIREMENTS: DAT-639 */
-		struct AssignmentStatement {
-			static constexpr auto rule = [] {
-				auto right_brace = lexy::dsl::lit_c<'}'>;
-
-				auto value_expression = lexy::dsl::p<ValueExpression>;
-				auto statement_list_expression = lexy::dsl::recurse_branch<StatementListBlock>;
-
-				auto rhs_recover = lexy::dsl::recover(value_expression, statement_list_expression).limit(right_brace);
-				auto rhs_try = lexy::dsl::try_(value_expression | statement_list_expression, rhs_recover);
-
-				auto identifier =
-					dsl::p<Identifier> >>
-					(lexy::dsl::equal_sign >>
-							rhs_try |
-						lexy::dsl::else_ >> lexy::dsl::return_);
-
-				auto string_expression = dsl::p<StringExpression>;
-				auto statement_list = lexy::dsl::recurse_branch<StatementListBlock>;
-
-				return identifier | string_expression | statement_list;
-			}();
-
-			static constexpr auto value = dsl::callback<ast::Statement*>(
-				[](detail::IsParseState auto& state, const char* pos, ast::IdentifierValue* name, ast::Value* initializer) -> ast::AssignStatement* {
-					return state.ast().template create<ast::AssignStatement>(pos, name, initializer);
-				},
-				[](detail::IsParseState auto& state, bool&, const char* pos, ast::IdentifierValue* name, ast::Value* initializer) {
-					return state.ast().template create<ast::AssignStatement>(pos, name, initializer);
-				},
-				[](detail::IsParseState auto& state, bool&, bool&, const char* pos, ast::IdentifierValue* name, ast::Value* initializer) {
-					return state.ast().template create<ast::AssignStatement>(pos, name, initializer);
-				},
-				[](detail::IsParseState auto& state, bool&, bool&, const char* pos, ast::Value* name) {
-					return state.ast().template create<ast::ValueStatement>(pos, name);
-				},
-				[](detail::IsParseState auto& state, const char* pos, ast::Value* left, lexy::nullopt = {}) {
-					return state.ast().template create<ast::ValueStatement>(pos, left);
-				},
-				[](detail::IsParseState auto& state, bool&, const char* pos, ast::Value* left, lexy::nullopt = {}) {
-					return state.ast().template create<ast::ValueStatement>(pos, left);
-				},
-				[](detail::IsParseState auto& state, ast::Value* left) -> ast::ValueStatement* {
-					if (left == nullptr) { // May no longer be necessary
-						return nullptr;
-					}
-					return state.ast().template create<ast::ValueStatement>(state.ast().location_of(left), left);
-				},
-				[](detail::IsParseState auto& state, bool&, ast::Value* left) -> ast::ValueStatement* {
-					if (left == nullptr) { // May no longer be necessary
-						return nullptr;
-					}
-					return state.ast().template create<ast::ValueStatement>(state.ast().location_of(left), left);
-				});
-		};
-
-		/* REQUIREMENTS: DAT-640 */
-		struct StatementListBlock {
-			static constexpr auto rule = [] {
-				auto right_brace = lexy::dsl::lit_c<'}'>;
-
-				auto assign_statement = lexy::dsl::recurse_branch<AssignmentStatement>;
-
-				auto assign_try = lexy::dsl::try_(assign_statement, lexy::dsl::nullopt);
-				auto assign_opt = lexy::dsl::opt(lexy::dsl::list(assign_try));
-
-				auto curly_bracket = dsl::curly_bracketed(assign_opt + lexy::dsl::opt(lexy::dsl::semicolon));
-
-				return curly_bracket;
-			}();
-
-			static constexpr auto value =
-				lexy::as_list<ast::StatementList> >>
-				dsl::callback<ast::ListValue*>(
-					[](detail::IsParseState auto& state, const char* begin, auto&& list, const char* end) {
-						if constexpr (std::is_same_v<std::decay_t<decltype(list)>, lexy::nullopt>) {
-							return state.ast().template create<ast::ListValue>(ovdl::NodeLocation::make_from(begin, end));
-						} else {
-							return state.ast().template create<ast::ListValue>(ovdl::NodeLocation::make_from(begin, end), LEXY_MOV(list));
-						}
-					},
-					[](detail::IsParseState auto& state, const char* begin, auto&& list, auto&& semicolon, const char* end) {
-						if constexpr (std::is_same_v<std::decay_t<decltype(list)>, lexy::nullopt>) {
-							return state.ast().template create<ast::ListValue>(ovdl::NodeLocation::make_from(begin, end));
-						} else {
-							return state.ast().template create<ast::ListValue>(ovdl::NodeLocation::make_from(begin, end), LEXY_MOV(list));
-						}
-					});
-		};
+		static constexpr auto value = dsl::callback<ast::IdentifierValue*>(
+			[](detail::IsParseState auto& state, auto lexeme) {
+				auto value = state.ast().intern(lexeme);
+				return state.ast().template create<ast::IdentifierValue>(ovdl::NodeLocation::make_from(lexeme.begin(), lexeme.end()), value);
+			});
 	};
 
-	template<ParseOptions Options>
-	using StringExpression = typename SimpleGrammar<Options>::StringExpression;
+	/* REQUIREMENTS:
+	 * DAT-633
+	 * DAT-634
+	 */
+	struct StringExpression : lexy::token_production {
+		static constexpr auto rule = lexy::dsl::quoted(lexy::dsl::unicode::character);
+		static constexpr auto value =
+			dsl::as_string_view<> >>
+			dsl::callback<ast::StringValue*>(
+				[](detail::IsParseState auto& state, std::string_view sv) {
+					auto value = state.ast().intern(sv);
+					return state.ast().template create<ast::StringValue>(ovdl::NodeLocation::make_from(sv.data(), sv.data() + sv.size()), value);
+				});
+	};
 
-	template<ParseOptions Options>
-	using Identifier = typename SimpleGrammar<Options>::Identifier;
+	/* REQUIREMENTS: DAT-638 */
+	struct ValueExpression {
+		static constexpr auto rule = lexy::dsl::p<Identifier> | lexy::dsl::p<StringExpression>;
+		static constexpr auto value = lexy::forward<ast::Value*>;
+	};
 
-	template<ParseOptions Options>
-	using SAssignStatement = typename SimpleGrammar<Options>::SimpleAssignmentStatement;
+	struct SimpleAssignmentStatement {
+		static constexpr auto rule = [] {
+			auto right_brace = lexy::dsl::lit_c<'}'>;
+
+			auto value_expression = lexy::dsl::p<ValueExpression>;
+			auto statement_list_expression = lexy::dsl::recurse_branch<StatementListBlock>;
+
+			auto rhs_recover = lexy::dsl::recover(value_expression, statement_list_expression).limit(right_brace);
+			auto rhs_try = lexy::dsl::try_(value_expression | statement_list_expression, rhs_recover);
+
+			auto identifier =
+				dsl::p<Identifier> >>
+				(lexy::dsl::equal_sign >> rhs_try);
+
+			auto recover = lexy::dsl::recover(identifier).limit(right_brace);
+			return lexy::dsl::try_(identifier, recover);
+		}();
+
+		static constexpr auto value = construct<ast::AssignStatement>;
+	};
+
+	/* REQUIREMENTS: DAT-639 */
+	struct AssignmentStatement {
+		static constexpr auto rule = [] {
+			auto right_brace = lexy::dsl::lit_c<'}'>;
+
+			auto value_expression = lexy::dsl::p<ValueExpression>;
+			auto statement_list_expression = lexy::dsl::recurse_branch<StatementListBlock>;
+
+			auto rhs_recover = lexy::dsl::recover(value_expression, statement_list_expression).limit(right_brace);
+			auto rhs_try = lexy::dsl::try_(value_expression | statement_list_expression, rhs_recover);
+
+			auto identifier =
+				dsl::p<Identifier> >>
+				(lexy::dsl::equal_sign >>
+						rhs_try |
+					lexy::dsl::else_ >> lexy::dsl::return_);
+
+			auto string_expression = dsl::p<StringExpression>;
+			auto statement_list = lexy::dsl::recurse_branch<StatementListBlock>;
+
+			return identifier | string_expression | statement_list;
+		}();
+
+		static constexpr auto value = dsl::callback<ast::Statement*>(
+			[](detail::IsParseState auto& state, const char* pos, ast::IdentifierValue* name, ast::Value* initializer) -> ast::AssignStatement* {
+				return state.ast().template create<ast::AssignStatement>(pos, name, initializer);
+			},
+			[](detail::IsParseState auto& state, bool&, const char* pos, ast::IdentifierValue* name, ast::Value* initializer) {
+				return state.ast().template create<ast::AssignStatement>(pos, name, initializer);
+			},
+			[](detail::IsParseState auto& state, bool&, bool&, const char* pos, ast::IdentifierValue* name, ast::Value* initializer) {
+				return state.ast().template create<ast::AssignStatement>(pos, name, initializer);
+			},
+			[](detail::IsParseState auto& state, bool&, bool&, const char* pos, ast::Value* name) {
+				return state.ast().template create<ast::ValueStatement>(pos, name);
+			},
+			[](detail::IsParseState auto& state, const char* pos, ast::Value* left, lexy::nullopt = {}) {
+				return state.ast().template create<ast::ValueStatement>(pos, left);
+			},
+			[](detail::IsParseState auto& state, bool&, const char* pos, ast::Value* left, lexy::nullopt = {}) {
+				return state.ast().template create<ast::ValueStatement>(pos, left);
+			},
+			[](detail::IsParseState auto& state, ast::Value* left) -> ast::ValueStatement* {
+				if (left == nullptr) { // May no longer be necessary
+					return nullptr;
+				}
+				return state.ast().template create<ast::ValueStatement>(state.ast().location_of(left), left);
+			},
+			[](detail::IsParseState auto& state, bool&, ast::Value* left) -> ast::ValueStatement* {
+				if (left == nullptr) { // May no longer be necessary
+					return nullptr;
+				}
+				return state.ast().template create<ast::ValueStatement>(state.ast().location_of(left), left);
+			});
+	};
+
+	/* REQUIREMENTS: DAT-640 */
+	struct StatementListBlock {
+		static constexpr auto rule = [] {
+			auto right_brace = lexy::dsl::lit_c<'}'>;
+
+			auto assign_statement = lexy::dsl::recurse_branch<AssignmentStatement>;
+
+			auto assign_try = lexy::dsl::try_(assign_statement, lexy::dsl::nullopt);
+			auto assign_opt = lexy::dsl::opt(lexy::dsl::list(assign_try));
+
+			auto curly_bracket = dsl::curly_bracketed(assign_opt + lexy::dsl::opt(lexy::dsl::semicolon));
+
+			return curly_bracket;
+		}();
+
+		static constexpr auto value =
+			lexy::as_list<ast::StatementList> >>
+			dsl::callback<ast::ListValue*>(
+				[](detail::IsParseState auto& state, const char* begin, auto&& list, const char* end) {
+					if constexpr (std::is_same_v<std::decay_t<decltype(list)>, lexy::nullopt>) {
+						return state.ast().template create<ast::ListValue>(ovdl::NodeLocation::make_from(begin, end));
+					} else {
+						return state.ast().template create<ast::ListValue>(ovdl::NodeLocation::make_from(begin, end), LEXY_MOV(list));
+					}
+				},
+				[](detail::IsParseState auto& state, const char* begin, auto&& list, auto&& semicolon, const char* end) {
+					if constexpr (std::is_same_v<std::decay_t<decltype(list)>, lexy::nullopt>) {
+						return state.ast().template create<ast::ListValue>(ovdl::NodeLocation::make_from(begin, end));
+					} else {
+						return state.ast().template create<ast::ListValue>(ovdl::NodeLocation::make_from(begin, end), LEXY_MOV(list));
+					}
+				});
+	};
 
 	template<ovdl::detail::string_literal Keyword, auto Production, auto Value = dsl::default_kw_value<ast::IdentifierValue, Keyword>>
 	using keyword_rule = dsl::keyword_rule<
@@ -367,17 +223,14 @@ namespace ovdl::v2script::grammar {
 		ast::AssignStatement,
 		Keyword, Production, Value>;
 
-	template<ParseOptions Options>
-	struct BasicFile {
+	struct File {
 		// Allow arbitrary spaces between individual tokens.
 		static constexpr auto whitespace = whitespace_specifier | comment_specifier;
 
 		static constexpr auto rule = lexy::dsl::position(
 			lexy::dsl::terminator(lexy::dsl::eof)
-				.opt_list(lexy::dsl::p<typename SimpleGrammar<Options>::AssignmentStatement>));
+				.opt_list(lexy::dsl::p<AssignmentStatement>));
 
 		static constexpr auto value = lexy::as_list<ast::StatementList> >> construct<ast::FileTree>;
 	};
-
-	using File = BasicFile<NoStringEscapeOption>;
 }

--- a/src/openvic-dataloader/v2script/TriggerGrammar.hpp
+++ b/src/openvic-dataloader/v2script/TriggerGrammar.hpp
@@ -10,7 +10,7 @@
 
 namespace ovdl::v2script::grammar {
 	struct TriggerStatement {
-		static constexpr auto rule = lexy::dsl::p<SAssignStatement<StringEscapeOption>>;
+		static constexpr auto rule = lexy::dsl::p<SimpleAssignmentStatement>;
 
 		static constexpr auto value = lexy::forward<ast::AssignStatement*>;
 	};

--- a/tests/src/csv/Parser.cpp
+++ b/tests/src/csv/Parser.cpp
@@ -781,7 +781,7 @@ TEST_CASE("CSV Parse", "[csv-parse]") {
 	// Compiler bug hangs if it can see if there is any reference to \x8F in a character
 #if !defined(_OVDL_TEST_UBUNTU_GCC_12_BUG_)
 	SECTION(";$NAME$ wurde in $PROV$ gebaut.;ID'\\x8F' DO;") {
-		static auto buffer = ";$NAME$ wurde in $PROV$ gebaut.;ID\x8F DO;";
+		static auto buffer = ";$NAME$ wurde in $PROV$ gebaut.;ID\x8F DO;"sv;
 		parser.load_from_string(buffer);
 
 		CHECK_PARSE();
@@ -790,42 +790,44 @@ TEST_CASE("CSV Parse", "[csv-parse]") {
 		CHECK_FALSE(line_list.empty());
 		CHECK(ranges::size(line_list) == 1);
 
-		const LineObject& line = line_list.front();
-		CHECK_FALSE(line.empty());
-		CHECK(ranges::size(line) == 2);
-		CHECK(line.value_count() == 3);
-		CHECK(line.prefix_end() == 1);
-		CHECK(line.suffix_end() == 3);
+		if (!line_list.empty()) {
+			const LineObject& line = line_list.front();
+			CHECK_FALSE(line.empty());
+			CHECK(ranges::size(line) == 2);
+			CHECK(line.value_count() == 3);
+			CHECK(line.prefix_end() == 1);
+			CHECK(line.suffix_end() == 3);
 
-		for (const auto [index, val] : line | ranges::views::enumerate) {
-			CAPTURE(index);
-			CHECK_FALSE_OR_CONTINUE(val.second.empty());
-			switch (index) {
-				case 0:
-					CHECK_OR_CONTINUE(val.first == 1);
-					CHECK_OR_CONTINUE(val.second == "$NAME$ wurde in $PROV$ gebaut."sv);
-					break;
-				case 1:
-					CHECK_OR_CONTINUE(val.first == 2);
-					CHECK_OR_CONTINUE(val.second == "IDĘ DO"sv);
-					break;
-				case 2:
-					CHECK_OR_CONTINUE(val.first == 3);
-					CHECK_OR_CONTINUE(val.second == ""sv);
-					break;
-				default: CHECK_OR_CONTINUE(false); break;
+			for (const auto [index, val] : line | ranges::views::enumerate) {
+				CAPTURE(index);
+				CHECK_FALSE_OR_CONTINUE(val.second.empty());
+				switch (index) {
+					case 0:
+						CHECK_OR_CONTINUE(val.first == 1);
+						CHECK_OR_CONTINUE(val.second == "$NAME$ wurde in $PROV$ gebaut."sv);
+						break;
+					case 1:
+						CHECK_OR_CONTINUE(val.first == 2);
+						CHECK_OR_CONTINUE(val.second == "IDĘ DO"sv);
+						break;
+					case 2:
+						CHECK_OR_CONTINUE(val.first == 3);
+						CHECK_OR_CONTINUE(val.second == ""sv);
+						break;
+					default: CHECK_OR_CONTINUE(false); break;
+				}
 			}
-		}
 
-		CHECK(line.value_count() == 3);
+			CHECK(line.value_count() == 3);
 
-		for (const auto index : ranges::views::iota(size_t(0), line.value_count())) {
-			CAPTURE(index);
-			switch (index) {
-				case 0: CHECK_OR_CONTINUE(line.get_value_for(index) == ""sv); break;
-				case 1: CHECK_OR_CONTINUE(line.get_value_for(index) == "$NAME$ wurde in $PROV$ gebaut."sv); break;
-				case 2: CHECK_OR_CONTINUE(line.get_value_for(index) == "IDĘ DO"sv); break;
-				default: CHECK_OR_CONTINUE(false); break;
+			for (const auto index : ranges::views::iota(size_t(0), line.value_count())) {
+				CAPTURE(index);
+				switch (index) {
+					case 0: CHECK_OR_CONTINUE(line.get_value_for(index) == ""sv); break;
+					case 1: CHECK_OR_CONTINUE(line.get_value_for(index) == "$NAME$ wurde in $PROV$ gebaut."sv); break;
+					case 2: CHECK_OR_CONTINUE(line.get_value_for(index) == "IDĘ DO"sv); break;
+					default: CHECK_OR_CONTINUE(false); break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Make loading of unknown encoding an error
Change Encoding to uint8_t
Fix possible dangling reference crash in "CSV Parse" test case
Add Windows-1252 "V2Script String Simple Parse" test section
Add Windows-1251 "V2Script String Simple Parse" test section
Add UTF8 "V2Script String Simple Parse" test section