### PR TITLE
Overhaul build.yml workflow

### DIFF
--- a/.github/actions/openvic-dl-build/action.yml
+++ b/.github/actions/openvic-dl-build/action.yml
@@ -1,0 +1,98 @@
+name: Build OpenVic-Dataloader
+description: Setup and Build OpenVic-Dataloader with the provided options
+
+inputs:
+  identifier:
+    description: Identifier of this build
+  target:
+    description: Target type to build for
+    required: true
+  platform:
+    description: Platform to build for
+    required: true
+  arch:
+    description: Architecture to build for
+    required: true
+  scons-flags:
+    description: Additional flags to send to SCons
+    default: ''
+  build-library:
+    description: Whether to build the library file
+    default: 'true'
+  compliance-type:
+    description: Type of Unicode compliance for the dataloader to support (error, error_replace, loose)
+    default: 'loose'
+  cache-base-branch:
+    description: Branch to base the cache upon
+    default: 'master'
+  disable-cache:
+    description: Whether to disable the build cache
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup build cache
+      uses: OpenVicProject/openvic-cache@master
+      if: ${{ !inputs.disable-cache }}
+      with:
+        cache-name: ${{ inputs.identifier }}
+        base-branch: ${{ inputs.cache-base-branch }}
+      continue-on-error: true
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.x"
+
+    - name: Set up SCons
+      shell: bash
+      run: |
+        python -c "import sys; print(sys.version)"
+        python -m pip install scons
+        scons --version
+
+    - name: Install APT dependencies
+      if: ${{ inputs.platform == 'linux' }}
+      uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+      with:
+        packages: build-essential pkg-config libtbb-dev
+
+    - name: Install and Set g++ to version 13
+      if: ${{ inputs.platform == 'linux' }}
+      shell: sh
+      run: |
+        g++ --version
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+        sudo apt update -y
+        sudo apt install g++-13
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13
+        sudo update-alternatives --set g++ /usr/bin/g++-13
+        g++ --version
+
+    - name: Compile with SCons
+      uses: OpenVicProject/openvic-build@master
+      with:
+        platform: ${{ inputs.platform }}
+        target: ${{ inputs.target }}
+        sconsflags: arch=${{ inputs.arch }} ${{ inputs.build-library && 'build_ovdl_library=yes' }} compliance_type=${{ inputs.compliance-type }} ${{ inputs.scons-flags }}
+
+    - name: Delete compilation files
+      if: ${{ inputs.platform == 'windows' }}
+      shell: pwsh
+      run: |
+        Remove-Item bin/* -Include *.exp,*.pdb -Force
+
+    - name: Upload library artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ github.event.repository.name }}-${{ inputs.identifier }}-library
+        path: |
+          ${{ github.workspace }}/bin/libopenvic-dataloader.*
+
+    - name: Upload executable artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ github.event.repository.name }}-${{ inputs.identifier }}-executable
+        path: |
+          ${{ github.workspace }}/bin/openvic-dataloader.headless.*

--- a/.github/actions/openvic-dl-release/action.yml
+++ b/.github/actions/openvic-dl-release/action.yml
@@ -1,0 +1,261 @@
+name: Release OpenVic-Dataloader
+description: Setup, Build, and Release OpenVic-Dataloader
+
+inputs:
+  tag-name:
+    description: 'Name to assign to the tag (default: github.ref)'
+    default: ${{ github.ref }}
+  target-repo:
+    description: Repository to publish this release to
+    default: 'OpenVic-Dataloader'
+  to-ref:
+    description: 'Tag/Commit to publish this release to (default: github.ref)'
+    default: ${{ github.ref }}
+  from-ref:
+    description: Tag/Commit to source the release notes from
+    required: true
+  from-tag:
+    description: 'Tag name being sourced from (default: from-ref)'
+    default: ''
+  snapshot-release:
+    description: Whether the release is a snapshot release
+    default: 'false'
+  latest:
+    description: Latest
+    default: 'false'
+  prerelease:
+    description: Pre-release
+    required: true
+  src-token:
+    description: Github token for source repository
+    required: true
+  target-token:
+    description: Github token for target repository
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup regex variables
+      shell: bash
+      run: |
+        echo "SEMVER_REGEX=^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})(-(alpha|beta|rc)\.([1-9][0-9]*))?$" >> $GITHUB_ENV
+        echo "SEMVER_SNAPSHOT_REGEX=^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})-(snapshot|snapshot\.dev)\.([1-9][0-9]*)\+([0-9a-fA-F]{40})$" >> $GITHUB_ENV
+        echo "SHA_REGEX=^[0-9a-fA-F]{40}$" >> $GITHUB_ENV
+
+    - name: Validate input values
+      shell: bash
+      env:
+        INPUTS_TAG_NAME: ${{ inputs.tag-name }}
+        INPUTS_TARGET_REPO: ${{ inputs.target-repo }}
+        INPUTS_TO_REF: ${{ inputs.to-ref }}
+        INPUTS_FROM_REF: ${{ inputs.from-ref }}
+        INPUTS_FROM_TAG: ${{ inputs.from-tag }}
+        INPUTS_SNAPSHOT_RELEASE: ${{ inputs.snapshot-release }}
+        INPUTS_LATEST: ${{ inputs.latest }}
+        INPUTS_PRERELEASE: ${{ inputs.prerelease }}
+        INPUTS_SRC_TOKEN: ${{ inputs.src-token }}
+        INPUTS_TARGET_TOKEN: ${{ inputs.target-token }}
+      run: |
+        # Can report error for every validation check
+        EXIT_STATUS=0
+
+        validate_non_empty () {
+          [[ -n ${1-} ]] && return
+          echo "::error::${2-parameter} is empty."
+          EXIT_STATUS=1
+          false
+        }
+
+        validate_semver () {
+          if validate_non_empty "$1" "${2-}"; then
+            [[ ${1-} =~ $SEMVER_REGEX ]] && return
+            [[ ${1-} =~ $SEMVER_SNAPSHOT_REGEX ]] && return
+          fi
+
+          if [[ -n ${2-} ]]; then
+            echo "::error::$2 is not a valid semver string for versioning starting with v. Valid prerelease values are 'alpha', 'beta', 'rc', 'snapshot', and 'snapshot.dev'. A count value must follow all, starting from 1. 'snapshot', 'snapshot.dev' must include the full commit SHA as a build string."
+            EXIT_STATUS=1
+          fi
+          false
+        }
+
+        validate_ref () {
+          local VALUE=${1#'refs/tags/'}
+
+          if validate_non_empty "$VALUE" "${2-}"; then
+            validate_semver "$VALUE" && return
+            [[ ${VALUE:-} =~ $SHA_REGEX ]] && return
+          fi
+
+          echo "::error::${2-parameter} is not a git commit SHA or valid semver string for versioning starting with v. Valid prerelease values are 'alpha', 'beta', 'rc', 'snapshot', and 'snapshot.dev'. A count value must follow all, starting from 1. 'snapshot', 'snapshot.dev' must include the full commit SHA as a build string."
+          EXIT_STATUS=1
+          false
+        }
+
+        if [[ $INPUTS_TAG_NAME == refs/tags/* ]]; then
+          INPUTS_TAG_NAME=${INPUTS_TAG_NAME#'refs/tags/'}
+        fi
+
+        validate_semver "$INPUTS_TAG_NAME" "inputs.tag-name"
+
+        if [[ "$GITHUB_REPOSITORY_OWNER/$INPUTS_TARGET_REPO" != $GITHUB_REPOSITORY ]]; then
+          if ! validate_non_empty "$INPUTS_TARGET_REPO" "inputs.target-repo" && [[ -z $INPUTS_TARGET_TOKEN ]]; then
+            echo "::error::inputs.target-repo is set to a different repository and the inputs.target-token is not set."
+            EXIT_STATUS=1
+          fi
+        fi
+
+        validate_ref "$INPUTS_TO_REF" "inputs.to-ref"
+
+        validate_ref "$INPUTS_FROM_REF" "inputs.from-ref"
+
+        if [[ -n $INPUTS_FROM_TAG ]]; then
+          validate_ref "$INPUTS_FROM_TAG" "inputs.from-tag"
+        fi
+
+        validate_non_empty "$INPUTS_SRC_TOKEN" "inputs.src-token"
+
+        exit $EXIT_STATUS
+
+    - name: Copy src-token to env.TARGET_TOKEN
+      if: format('{0}/{1}', github.repository_owner, inputs.target-repo) == github.repository
+      shell: bash
+      env:
+        INPUTS_SRC_TOKEN: ${{ inputs.src-token }}
+      run: echo "TARGET_TOKEN=$INPUTS_SRC_TOKEN" >> $GITHUB_ENV
+
+    - name: Copy target-token to env.TARGET_TOKEN
+      if: format('{0}/{1}', github.repository_owner, inputs.target-repo) != github.repository
+      shell: bash
+      env:
+        INPUTS_TARGET_TOKEN: ${{ inputs.target-token }}
+      run: echo "TARGET_TOKEN=$INPUTS_TARGET_TOKEN" >> $GITHUB_ENV
+
+    - name: Set TO_TAG from to-ref
+      if: inputs.tag-name == inputs.to-ref
+      shell: bash
+      env:
+        INPUTS_TO_REF: ${{ inputs.to-ref }}
+      run: echo "TO_TAG=${INPUTS_TO_REF#'refs/tags/'}" >> $GITHUB_ENV
+
+    - name: Set TO_TAG from tag-name
+      if: inputs.tag-name != inputs.to-ref
+      shell: bash
+      env:
+        INPUTS_TAG_NAME: ${{ inputs.tag-name }}
+      run: echo "TO_TAG=$INPUTS_TAG_NAME" >> $GITHUB_ENV
+
+    - name: Build Release Notes
+      if: inputs.snapshot-release == 'false'
+      uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
+      env:
+        GITHUB_TOKEN: ${{ inputs.src-token }}
+      with:
+        configuration: "${{ github.action_path }}/release-notes-configuration.json"
+        toTag: ${{ inputs.tag-name == inputs.to-ref && env.TO_TAG || inputs.to-ref }}
+        fromTag: ${{ inputs.from-ref }}
+        outputFile: release-notes.md
+
+    - name: Build Snapshot Release Notes
+      if: inputs.snapshot-release == 'true'
+      uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
+      env:
+        GITHUB_TOKEN: ${{ inputs.src-token }}
+      with:
+        configuration: "${{ github.action_path }}/snapshot-release-notes-configuration.json"
+        toTag: ${{ inputs.tag-name == inputs.to-ref && env.TO_TAG || inputs.to-ref }}
+        fromTag: ${{ inputs.from-ref }}
+        outputFile: release-notes.md
+
+    - name: Create release tag and name and set release name in release-notes.md
+      shell: bash
+      env:
+        INPUTS_FROM_TAG_OR_FROM_REF: ${{ inputs.from-tag || inputs.from-ref }}
+      run: |
+        if [[ $TO_TAG =~ $SEMVER_REGEX ]]; then
+          PRERELEASE_TYPE=${BASH_REMATCH[6]}
+          PRERELEASE_VERSION=${BASH_REMATCH[7]}
+
+          if [[ $PRERELEASE_TYPE == 'rc' ]]; then
+            PRERELEASE_NAME="Release Candidate"
+          else
+            PRERELEASE_NAME=${PRERELEASE_TYPE@u}
+          fi
+
+          PRERELEASE_VERSION_DATE=$PRERELEASE_VERSION
+        elif [[ $TO_TAG =~ $SEMVER_SNAPSHOT_REGEX ]]; then
+          PRERELEASE_TYPE=${BASH_REMATCH[5]}
+          PRERELEASE_VERSION=${BASH_REMATCH[6]}
+          PRERELEASE_HASH=${BASH_REMATCH[7]}
+
+          if [[ $PRERELEASE_TYPE == 'snapshot.dev' ]]; then
+            PRERELEASE_NAME="Dev Snapshot"
+          else
+            PRERELEASE_NAME=${PRERELEASE_TYPE@u}
+          fi
+
+          PRERELEASE_VERSION_DATE=$PRERELEASE_VERSION
+        fi
+
+        VERSION_CORE="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+
+        RELEASE_NAME="$(basename "$GITHUB_REPOSITORY") $(xargs <<< "$VERSION_CORE $PRERELEASE_NAME $PRERELEASE_VERSION_DATE")"
+        echo "RELEASE_NAME=$RELEASE_NAME" >> $GITHUB_ENV
+
+        # Keep up to date with .github/actions/openvic-dl-release release-notes configs
+        sed -i "s/<<RELEASE_NAME_REPLACEMENT>>/$RELEASE_NAME/g" release-notes.md
+        sed -i "s/<<FROM_TAG_NAME_REPLACEMENT>>/$INPUTS_FROM_TAG_OR_FROM_REF/g" release-notes.md
+
+        if [[ $INPUTS_FROM_TAG_OR_FROM_REF =~ $SHA_REGEX ]]; then
+          RELEASE_OR_COMMIT_PATH=commit
+        else
+          RELEASE_OR_COMMIT_PATH=releases\\/tag
+        fi
+
+        sed -i "s/<<RELEASE_OR_COMMIT_PATH>>/$RELEASE_OR_COMMIT_PATH/g" release-notes.md
+
+    - name: Replace <<REPO>> in release-notes.md
+      shell: bash
+      run: sed -i "s/<<REPO>>/$(sed 's;\/;\\\/;g' <<< "$GITHUB_REPOSITORY")/g" release-notes.md
+
+    - name: Make library directory
+      shell: sh
+      run: mkdir "$GITHUB_WORKSPACE/library/"
+
+    - name: Download library assets
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        path: "${{ github.workspace }}/library"
+        pattern: ${{ github.event.repository.name }}-*-library
+        merge-multiple: true
+
+    - name: Download executable assets
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: ${{ github.event.repository.name }}-*-executable
+        merge-multiple: true
+
+    - name: Zip library assets
+      uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # v0.7.6
+      with:
+        type: "zip"
+        filename: libopenvic-dataloader.zip
+        path: library
+
+    - name: Create and upload asset
+      uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+      with:
+        allowUpdates: true
+        artifacts: "libopenvic-dataloader.zip,openvic-dataloader.headless.**"
+        omitNameDuringUpdate: true
+        omitBodyDuringUpdate: true
+        name: "${{ env.RELEASE_NAME || '' }}"
+        tag: "${{ env.TO_TAG || '' }}"
+        commit: "${{ format('{0}/{1}', github.repository_owner, inputs.target-repo) == github.repository && !contains(inputs.to-ref, '.') && inputs.to-ref || '' }}"
+        bodyFile: "release-notes.md"
+        makeLatest: ${{ inputs.latest }}
+        prerelease: ${{ inputs.prerelease }}
+        draft: ${{ inputs.snapshot-release == 'false' }}
+        repo: "${{ inputs.target-repo }}"
+        token: ${{ env.TARGET_TOKEN }}

--- a/.github/actions/openvic-dl-release/release-notes-configuration.json
+++ b/.github/actions/openvic-dl-release/release-notes-configuration.json
@@ -1,0 +1,35 @@
+{
+    "base_branches": [
+        "master"
+    ],
+    "tag_resolver": {
+        "method": "sort",
+        "filter": {
+            "method": "regexr",
+            "pattern": "(\\d+\\.\\d+(?:\\.\\d+)?)(?:-((alpha|beta|rc)\\.(\\d+)))?"
+        }
+    },
+    "categories": [
+        {
+            "title": "### Enhancements & Features",
+            "labels": [
+                "enhancement"
+            ],
+            "exhaustive": true,
+            "consume": true
+        },
+        {
+            "title": "### Bug Fixes",
+            "labels": [
+                "bug"
+            ],
+            "exhaustive": true,
+            "consume": true
+        }
+    ],
+    "template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n## Changelog since [#{{FROM_TAG}}](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n#{{CHANGELOG}}\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "empty_template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n### No Pull Requests since [#{{FROM_TAG}}](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "pr_template": "* #{{TITLE}} by @#{{AUTHOR}} in #{{URL}}",
+    "max_pull_requests": 1000,
+    "max_back_track_time_days": 365
+}

--- a/.github/actions/openvic-dl-release/snapshot-release-notes-configuration.json
+++ b/.github/actions/openvic-dl-release/snapshot-release-notes-configuration.json
@@ -1,0 +1,28 @@
+{
+    "base_branches": [
+        "master"
+    ],
+    "categories": [
+        {
+            "title": "### Enhancements & Features",
+            "labels": [
+                "enhancement"
+            ],
+            "exhaustive": true,
+            "consume": true
+        },
+        {
+            "title": "### Bug Fixes",
+            "labels": [
+                "bug"
+            ],
+            "exhaustive": true,
+            "consume": true
+        }
+    ],
+    "template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n## Changelog since [#{{FROM_TAG}}](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n#{{CHANGELOG}}\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "empty_template": "# Release Notes for <<RELEASE_NAME_REPLACEMENT>>\n### No Pull Requests since [#{{FROM_TAG}}](https://github.com/<<REPO>>/<<RELEASE_OR_COMMIT_PATH>>/#{{FROM_TAG}})\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
+    "pr_template": "* #{{TITLE}} by @#{{AUTHOR}} in #{{URL}}",
+    "max_pull_requests": 1000,
+    "max_back_track_time_days": 365
+}

--- a/.github/changed-files.yml
+++ b/.github/changed-files.yml
@@ -1,0 +1,19 @@
+# We lack a convenient means of gathering *all* the changes when specializations are passed, so
+#  a catch-all variable is the easiest workaround.
+everything:
+  - "**"
+
+# Determines if build actions should occur after static checks are ran. Broadly speaking, these
+#  files changing would result in SCons rebuilding the engine, or are otherwise pertinent to the
+#  buildsystem itself.
+sources:
+  - .github/{actions/*,workflows}/*.yml
+  - "**/{SConstruct,SCsub,*.py}"
+  - "**/*.{hpp,cpp,inc}"
+  - scripts
+  - deps/**
+  - tests/**
+
+# Determines which files are appropriate for running clangd-tidy checks on.
+clangd:
+  - "**/*.{hpp,cpp,inc}"

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -1,0 +1,112 @@
+name: 🔢 Build Matrix
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-matrix:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: windows-debug
+            os: windows-latest
+            name: 🏁 Windows Debug
+            target: template_debug
+            platform: windows
+            arch: x86_64
+            test-bin-suffix: .md.exe
+
+          - identifier: windows-debug
+            os: windows-latest
+            name: 🏁 Windows Debug (Replace Error UTF Compliance)
+            target: template_debug
+            platform: windows
+            arch: x86_64
+            compliance_type: error_replace
+            test-bin-suffix: .md.exe
+
+          - identifier: windows-release
+            os: windows-latest
+            name: 🏁 Windows Release
+            target: template_release
+            platform: windows
+            arch: x86_64
+            test-bin-suffix: .md.exe
+
+          - identifier: macos-debug
+            os: macos-latest
+            name: 🍎 macOS (universal) Debug
+            target: template_debug
+            platform: macos
+            arch: universal
+
+          - identifier: macos-debug
+            os: macos-latest
+            name: 🍎 macOS (universal) Debug (Replace Error UTF Compliance)
+            target: template_debug
+            platform: macos
+            compliance_type: error_replace
+            arch: universal
+
+          - identifier: macos-release
+            os: macos-latest
+            name: 🍎 macOS (universal) Release
+            target: template_release
+            platform: macos
+            arch: universal
+
+          - identifier: linux-debug
+            os: ubuntu-22.04
+            name: 🐧 Linux Debug
+            target: template_debug
+            platform: linux
+            arch: x86_64
+
+          - identifier: linux-debug
+            os: ubuntu-22.04
+            name: 🐧 Linux Debug (Replace Error UTF Compliance)
+            target: template_debug
+            platform: linux
+            compliance_type: error_replace
+            arch: x86_64
+
+          - identifier: linux-debug
+            os: ubuntu-22.04
+            name: 🐧 Linux Debug (Build Error UTF Compliance)
+            target: template_debug
+            platform: linux
+            compliance_type: error
+            arch: x86_64
+
+          - identifier: linux-release
+            os: ubuntu-22.04
+            name: 🐧 Linux Release
+            target: template_release
+            platform: linux
+            arch: x86_64
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Build
+        uses: ./.github/actions/openvic-dl-build
+        with:
+          identifier: ${{ matrix.identifier }}
+          target: ${{ matrix.target }}
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          compliance-type: ${{ matrix.compliance_type || 'loose' }}
+
+      - name: Run tests
+        run: |
+          ./tests/bin/openvic-dataloader.tests.${{ matrix.platform }}.${{ matrix.target }}.${{ matrix.arch }}${{ matrix.test-bin-suffix || '' }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,185 +1,83 @@
-name: Builds
+name: 🖥️ Builds
 
-on: [push, pull_request]
-
-env:
-  OVDL_BASE_BRANCH: master
+on:
+  push:
+    branches: ['master']
+  pull_request:
+  merge_group:
+  workflow_dispatch:
 
 concurrency:
-  group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos
-  cancel-in-progress: true
+  group: ${{ github.workflow }}|${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
 
 jobs:
-  static-checks:
-    name: Code style, file formatting, and docs
-    runs-on: ubuntu-24.04
+  static-checks-builds:
+    name: 📊 Code style, file formatting, and docs
+    runs-on: ubuntu-latest
+    if: github.run_attempt > 1 || github.event_name == 'workflow_dispatch' || !vars.DISABLE_BUILDS
+    outputs:
+      changed-files: '"${{ steps.changed-files.outputs.clangd_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
+      sources-changed: ${{ steps.changed-files.outputs.sources_any_changed }}
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 2
+          fetch-depth: 0 # Treeless clone. Slightly less performant than a shallow clone, but makes finding diffs instantaneous.
+          filter: tree:0 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          persist-credentials: false
 
       - name: Install APT dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
         with:
           packages: libxml2-utils
 
       - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          safe_output: false # Output passed to environment variable to avoid command injection.
+          separator: '" "' # To account for paths with spaces, ensure our items are split by quotes internally.
+          skip_initial_fetch: true
+          files_yaml_from_source_file: .github/changed-files.yml
+
+      - name: Style checks via prek
+        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config diff.wsErrorHighlight all
-          if [ "${{ github.event_name }}" == "pull_request" -o "${{ github.event.forced }}" == "true" -o "${{ github.event.created }}" == "true" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r HEAD^1..HEAD 2> /dev/null || true)
-          elif [ "${{ github.event_name }}" == "push" -a "${{ github.event.created }}" == "false" ]; then
-            files=$(git diff-tree --no-commit-id --name-only -r ${{ github.event.before }}..${{ github.event.after }} 2> /dev/null || true)
-          fi
-          echo "$files" >> changed.txt
-          cat changed.txt
-          files=$(echo "$files" | xargs -I {} sh -c 'echo "\"./{}\""' | tr '\n' ' ')
-          echo "CHANGED_FILES=$files" >> $GITHUB_ENV
-
-      - name: Style checks via pre-commit
-        uses: pre-commit/action@v3.0.1
+          CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators
         with:
-          extra_args: --files ${{ env.CHANGED_FILES }}
+          extra-args: --files ${{ env.CHANGED_FILES }}
 
-  build:
-    runs-on: ${{matrix.os}}
-    name: ${{matrix.name}}
-    needs: static-checks
-    permissions: write-all
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - identifier: windows-debug
-            os: windows-latest
-            name: 🏁 Windows Debug (compliance_type=error_replace)
-            target: template_debug
-            platform: windows
-            arch: x86_64
-            compliance_type: error_replace
-          - identifier: windows-release
-            os: windows-latest
-            name: 🏁 Windows Release (compliance_type=loose)
-            target: template_release
-            platform: windows
-            arch: x86_64
-            compliance_type: loose
-          - identifier: macos-debug
-            os: macos-latest
-            name: 🍎 macOS (universal) Debug (compliance_type=error_replace)
-            target: template_debug
-            platform: macos
-            arch: universal
-            compliance_type: error_replace
-          - identifier: macos-release
-            os: macos-latest
-            name: 🍎 macOS (universal) Release (compliance_type=loose)
-            target: template_release
-            platform: macos
-            arch: universal
-            compliance_type: loose
-          - identifier: linux-debug
-            os: ubuntu-latest
-            name: 🐧 Linux Debug (compliance_type=error_replace)
-            target: template_debug
-            platform: linux
-            arch: x86_64
-            compliance_type: error_replace
-          - identifier: linux-release
-            os: ubuntu-latest
-            name: 🐧 Linux Release (compliance_type=loose)
-            target: template_release
-            platform: linux
-            arch: x86_64
-            compliance_type: loose
-
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v4.1.1
-        with:
-          submodules: recursive
-
-      - name: Setup OpenVic-Dataloader build cache
-        uses: OpenVicProject/openvic-cache@master
-        with:
-          cache-name: ${{ matrix.identifier }}
-          base-branch: ${{ env.OVDL_BASE_BRANCH }}
-        continue-on-error: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5.0.0
-        with:
-          python-version: "3.x"
-
-      - name: Set up SCons
-        shell: bash
-        run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install scons
-          scons --version
-
-      - name: Linux dependencies
-        if: ${{ matrix.platform == 'linux' }}
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qqq build-essential pkg-config
-          g++ --version
-
-      - name: Compile Dataloader
-        uses: OpenVicProject/openvic-build@master
-        with:
-          platform: ${{ matrix.platform }}
-          target: ${{ matrix.target }}
-          sconsflags: arch=${{ matrix.arch }} build_ovdl_library=yes run_ovdl_tests=yes compliance_type=${{ matrix.compliance_type }}
-
-      - name: Delete compilation files
-        if: ${{ matrix.platform == 'windows' }}
-        run: |
-          Remove-Item bin/* -Include *.exp,*.pdb -Force
-
-      - name: Upload library artifact
-        uses: actions/upload-artifact@v4.3.0
-        with:
-          name: ${{ github.event.repository.name }}-${{ matrix.identifier }}-library
-          path: |
-            ${{ github.workspace }}/bin/libopenvic-dataloader.*
-
-      - name: Upload executable artifact
-        uses: actions/upload-artifact@v4.3.0
-        with:
-          name: ${{ github.event.repository.name }}-${{ matrix.identifier }}-executable
-          path: |
-            ${{ github.workspace }}/bin/openvic-dataloader.headless.*
-
-      - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.6
-        with:
-          type: "zip"
-          filename: "../../../libopenvic-dataloader.${{ matrix.platform }}.${{ matrix.arch }}.zip"
-          directory: "${{ github.workspace }}/bin/"
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-
-      - name: Create and upload asset
-        uses: ncipollo/release-action@v1.13.0
-        with:
-          allowUpdates: true
-          artifacts: "libopenvic-dataloader.${{ matrix.platform }}.${{ matrix.arch }}.zip"
-          omitNameDuringUpdate: true
-          omitBodyDuringUpdate: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+  build-master:
+    name: 🛠️ Build
+    needs: static-checks-builds
+    if: needs.static-checks-builds.outputs.sources-changed == 'true' || github.event_name != 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-matrix.yml
 
   merge-library-files:
-    runs-on: ubuntu-latest
-    needs: build
     name: 📚 Merge Library Files
+    runs-on: ubuntu-latest
+    needs: build-master
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4.3.0
+        uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           delete-merged: true
           name: ${{ github.event.repository.name }}-library
           pattern: ${{ github.event.repository.name }}-*-library
+
+  validate-master:
+    name: ✅ Validate Success
+    if: always()
+    needs: [static-checks-builds, build-master, merge-library-files]
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Check
+        uses: re-actors/alls-green@a638d6464689bbb24c325bb3fe9404d63a913030
+        with:
+          allowed-skips: static-checks-builds, build-master, merge-library-files
+          jobs: ${{ toJson(needs) }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,138 @@
+name: 🚀 Releases
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions: {}
+
+env:
+  SEMVER_REGEX: ^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})(-(alpha|beta|rc)\.([1-9][0-9]*))?$
+  SEMVER_SNAPSHOT_REGEX: ^v(0|[1-9][0-9]*)((\.(0|[1-9][0-9]*)){1,2})-(snapshot|snapshot\.dev)\.([1-9][0-9]*)\+([0-9a-fA-F]{40})$
+
+jobs:
+  static-checks-release:
+    name: Code style, file formatting, and docs
+    if: vars.DISABLE_TAG_RELEASES != true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # Treeless clone. Slightly less performant than a shallow clone, but makes finding diffs instantaneous.
+          filter: tree:0 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          persist-credentials: false
+
+      - name: Validate tag
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          validate_version () {
+            [[ $1 =~ $SEMVER_REGEX ]] && return
+            [[ $1 =~ $SEMVER_SNAPSHOT_REGEX ]] && return
+
+            echo "::error::${2:-parameter} is not a valid semver string for versioning starting with v. Valid prerelease values are 'alpha', 'beta', 'rc', 'snapshot', and 'snapshot.dev'. A count value must follow all prerelease tags, starting from 1. 'snapshot' and 'snapshot.dev' must include the full commit SHA as a build string"
+            false
+          }
+
+          if ! validate_version "$GITHUB_REF_NAME" "github.ref (tag)"; then
+            exit 1
+          fi
+
+      - name: Install APT dependencies
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
+        with:
+          packages: libxml2-utils
+
+      - name: Style checks via prek
+        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
+
+  build-release:
+    name: ${{ matrix.name }} Release
+    needs: static-checks-release
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - identifier: windows-release
+            os: windows-latest
+            name: 🏁 Build Windows
+            target: template_release
+            platform: windows
+            arch: x86_64
+            scons-flags: ''
+
+          - identifier: macos-release
+            os: macos-latest
+            name: 🍎 Build macOS
+            target: template_release
+            platform: macos
+            arch: universal
+            scons-flags: lto=full
+
+          - identifier: linux-release
+            os: ubuntu-latest
+            name: 🐧 Build Linux
+            runner: ubuntu-22.04
+            target: template_release
+            platform: linux
+            arch: x86_64
+            scons-flags: lto=full use_static_cpp=yes
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Build
+        uses: ./.github/actions/openvic-dl-build
+        with:
+          identifier: ${{ matrix.identifier }}
+          target: ${{ matrix.target }}
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          disable-cache: true
+          scons-flags: use_hot_reload=no build_ovdl_tests=no ${{ matrix.scons-flags }}
+
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: build-release
+    permissions:
+      contents: write  # May be needed to publish release
+    env:
+      IS_PRERELEASE: ${{
+          contains(github.ref, '-alpha') ||
+          contains(github.ref, '-beta') ||
+          contains(github.ref, '-rc') ||
+          contains(github.ref, '-snapshot')
+        }}
+      IS_SNAPSHOT: ${{ contains(github.ref, '-snapshot') }}
+    steps:
+      - name: Shallow Clone
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1 # See: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+          persist-credentials: false
+
+      - name: Get FROM_REF
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXCLUDE_PRE_RELEASES: ${{ !env.IS_PRERELEASE && '--exclude-pre-releases' || '' }}
+          EXCLUDE_SNAPSHOTS: ${{ !env.IS_SNAPSHOT && '| select(.tagName | contains("-snapshot") | not)' || '' }}
+        run:
+          echo "FROM_REF=$(gh release list $EXCLUDE_PRE_RELEASES --json tagName --jq "[.[] $EXCLUDE_SNAPSHOTS.tagName][0]")" >> $GITHUB_ENV
+
+      - name: Publish Release
+        uses: ./.github/actions/openvic-dl-release
+        with:
+          latest: ${{ !env.IS_PRERELEASE && !env.IS_SNAPSHOT }}
+          prerelease: ${{ env.IS_PRERELEASE }}
+          snapshot-release: ${{ env.IS_SNAPSHOT }}
+          from-ref: ${{ env.FROM_REF || vars.DEFAULT_COMMIT_HASH }}
+          src-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add validate-master as required CI job
Extract build matrix to build-matrix.yml workflow
Add support for tagged releases
Separate unit test runs from build process
Update ubuntu runner to 22.04
Move pre-commit checks to prek
Update awalsh128/cache-apt-pkgs-action to v1.6.1
Pin workflow actions to commits
Remove non-master push builds
Update ubuntu builds to use GCC 13

Requires the Github variable DEFAULT_COMMIT_HASH to an existing repository hash. (Already set to [`5e49c615dd4b760926935696e54f35a387352b6f`](https://github.com/OpenVicProject/OpenVic-Dataloader/commit/5e49c615dd4b760926935696e54f35a387352b6f))

These templates follow [semver](https://semver.org/):

- Template for alpha releases: `MAJOR.MINOR.PATCH-alpha.COUNT`.
- Template for beta releases: `MAJOR.MINOR.PATCH-beta.COUNT`.
- Template for release candidate releases: `MAJOR.MINOR.PATCH-rc.COUNT`.
- Template for full releases: `MAJOR.MINOR.PATCH`.
- Template for snapshot releases: `MAJOR.MINOR.PATCH-snapshot.COUNT+SHA`.
- Template for dev snapshot releases: `MAJOR.MINOR.PATCH-snapshot.dev.COUNT+SHA`.

`.PATCH` is optional.
`COUNT` refers to how many of this release type there is with the release, so the first alpha for 0.1 would be `0.1-alpha.1`, `COUNT` should be reset on the next major, minor, or patch change.

Tags must be pushed in this form. The releases automatically generate the release notes with PRs since the last update. Full releases only consider the difference between non-prerelease releases. Alphas, betas, and release candidates don't consider snapshots. Snapshots consider every release.

To disable trigger releases via tags you can set the Github variable `DISABLE_TAG_RELEASES` to true.
To disable PR and master commit builds you can set the Github variable `DISABLE_BUILDS` to true.