### PR TITLE
Fix cache-step condition in openvic-dl-build/action.yml

### DIFF
--- a/.github/actions/openvic-dl-build/action.yml
+++ b/.github/actions/openvic-dl-build/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Setup build cache
       uses: OpenVicProject/openvic-cache@master
-      if: ${{ !inputs.disable-cache }}
+      if: ${{ inputs.disable-cache != 'true' }}
       with:
         cache-name: ${{ inputs.identifier }}
         base-branch: ${{ inputs.cache-base-branch }}


### PR DESCRIPTION
Change the cache setup condition to correctly check the string input value. GitHub Actions inputs are strings, so replacing `if: ${{ !inputs.disable-cache }}` with `if: ${{ inputs.disable-cache != 'true' }}` ensures the cache step runs unless the caller explicitly sets disable-cache to 'true'. This fixes an issue where the cache was never used when disable-cache was omitted or set to other truthy values. Affects .github/actions/openvic-dl-build/action.yml and all build workflows.