### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.0
+    rev: v22.1.8
     hooks:
       - id: clang-format
         files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|inc)$
@@ -14,16 +14,24 @@ repos:
     hooks:
       - id: clang-tidy
         files: \.(c|h|cpp|hpp)$
-        args: [--fix, --quiet, --use-color]
+        args:
+          [
+            --fix,
+            --quiet,
+            --use-color,
+            -p=compile_commands.json,
+            -extra-arg=-Wno-unknown-warning-option,
+            -checks=-modernize-use-bool-literals,
+          ]
         types_or: [text]
-        additional_dependencies: [clang-tidy==19.1.0]
+        additional_dependencies: [clang-tidy==22.1.8]
         require_serial: true
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.15.22
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
         files: (\.py|SConstruct|SCsub)$
         types_or: [text]
@@ -32,7 +40,7 @@ repos:
         types_or: [text]
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.44.0
+    rev: v1.48.0
     hooks:
       - id: typos
         # exclude: |

--- a/include/openvic-dataloader/Parser.hpp
+++ b/include/openvic-dataloader/Parser.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 #include <string_view>
 

--- a/include/openvic-dataloader/detail/HashAlgorithm.hpp
+++ b/include/openvic-dataloader/detail/HashAlgorithm.hpp
@@ -10,7 +10,7 @@ namespace ovdl::detail {
 		static constexpr std::uint64_t fnv_prime = 1099511628211ull;
 
 	public:
-		explicit DefaultHash() : _hash(fnv_basis) {}
+		explicit DefaultHash() {}
 
 		DefaultHash(DefaultHash&&) = default;
 		DefaultHash& operator=(DefaultHash&&) = default;
@@ -48,6 +48,6 @@ namespace ovdl::detail {
 		}
 
 	private:
-		std::uint64_t _hash;
+		std::uint64_t _hash = fnv_basis;
 	};
 }

--- a/include/openvic-dataloader/detail/OStreamOutputIterator.hpp
+++ b/include/openvic-dataloader/detail/OStreamOutputIterator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <ostream>
 
 namespace ovdl::detail {


### PR DESCRIPTION
Update clang-format to v22.1.8
Change ruff hook to ruff-check hook
Update ruff-check/ruff-format to v0.15.22
Update typos to v1.48.0
Update clang-tidy dependency to 22.1.8
Apply clang-tidy fixes